### PR TITLE
feat: @AuthenticationPrincipal 기반 로그인 사용자 정보 조회 기능 추가

### DIFF
--- a/src/main/java/sparta/paymentsystemserver/domain/auth/dto/LoginUserData.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/auth/dto/LoginUserData.java
@@ -1,0 +1,4 @@
+package sparta.paymentsystemserver.domain.auth.dto;
+
+public record LoginUserData (Long userId, String email) {
+}

--- a/src/main/java/sparta/paymentsystemserver/global/jwt/JwtFilter.java
+++ b/src/main/java/sparta/paymentsystemserver/global/jwt/JwtFilter.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
+import sparta.paymentsystemserver.domain.auth.dto.LoginUserData;
 
 import java.io.IOException;
 import java.util.List;
@@ -56,12 +57,12 @@ public class JwtFilter extends OncePerRequestFilter {
                 sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "ACCESS_TOKEN_EXPIRED");
                 return;
             }
-            //CustomUserDetails 필요하면 추후 추가
-//            String email = jwtUtil.getEmail(token);
+            String email = jwtUtil.getEmail(token);
             Long id = jwtUtil.getId(token);
 
+            LoginUserData loginUserData = new LoginUserData(id, email);
             Authentication authentication =
-                    new UsernamePasswordAuthenticationToken(id, null, List.of());
+                    new UsernamePasswordAuthenticationToken(loginUserData, null, List.of());
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
             filterChain.doFilter(request, response);


### PR DESCRIPTION
**작업 설명**
 @AuthenticationPrincipal 를 기반하여 컨트롤러에서 userId , email 정보를 조회할 수 있도록 추가 작업

사용방법 
```
  @GetMapping("/test")
  public ResponseEntity<Void> test(@AuthenticationPrincipal LoginUserData loginUserData) {
      return ResponseEntity.ok(loginUserData.id());
  }
```
 
resolve #29 