### PR TITLE
feat: 결제 시도 생성 초기 로직 구현

### DIFF
--- a/src/main/java/sparta/paymentsystemserver/domain/payment/controller/PamentController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/controller/PamentController.java
@@ -1,5 +1,0 @@
-package sparta.paymentsystemserver.domain.payment.controller;
-
-// 결제를 생성하고 확정, 환불을 하는 API입니다
-public class PamentController {
-}

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/controller/PaymentController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/controller/PaymentController.java
@@ -1,0 +1,31 @@
+package sparta.paymentsystemserver.domain.payment.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sparta.paymentsystemserver.domain.payment.dto.CreatePaymentRequest;
+import sparta.paymentsystemserver.domain.payment.dto.CreatePaymentResponse;
+import sparta.paymentsystemserver.domain.payment.service.PaymentService;
+
+// 결제를 생성하고 확정, 환불을 하는 API입니다
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    // 결제 시도 생성 API JWT에서 꺼낸 현재 로그인 사용자 정보 사용
+    @PostMapping
+    public CreatePaymentResponse createPayment(
+            @Valid @RequestBody CreatePaymentRequest request,
+            @AuthenticationPrincipal Long userId
+    ) {
+        return paymentService.createPayment(request, userId);
+    }
+
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/dto/CreatePaymentResponse.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/dto/CreatePaymentResponse.java
@@ -1,6 +1,13 @@
 package sparta.paymentsystemserver.domain.payment.dto;
 
-// 결제 시도 생성 응답
+// 결제 시도 생성 응답 dto
+// 이 단계는 일단 결제 완료가 아니라 결제창을 열기 위한 준비 완료 상태를 반환
 public record CreatePaymentResponse(
+        String paymentId,
+        String orderId,
+        long totalAmount,
+        long pointsToUse,
+        long externalAmount,
+        String status
 ) {
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/entity/Payment.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/entity/Payment.java
@@ -5,7 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.dialect.unique.CreateTableUniqueDelegate;
+import sparta.paymentsystemserver.domain.order.entity.Order;
 import sparta.paymentsystemserver.domain.user.entity.User;
 import sparta.paymentsystemserver.global.config.BaseEntity;
 
@@ -29,9 +29,9 @@ public class Payment extends BaseEntity {
     private String paymentId;
 
     // 어떤 주문에 대한 결제 시도인지 연결하는 참조
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "order_id")
-//    private Order order;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
 
     // 결제를 수행한 사용자
     @ManyToOne(fetch = FetchType.LAZY)
@@ -77,53 +77,53 @@ public class Payment extends BaseEntity {
     // 결제 실패 시 원인을 남기는 필드
     @Column(length = 300)
     private String failureReason;
-//
-//    @Builder
-//    private Payment(
-//            String paymentId,
-//            Order order,
-//            User user,
-//            PaymentProvider provider,
-//            PaymentStatus status,
-//            long totalAmount,
-//            long pointsToUse,
-//            long externalAmount,
-//            String currency
-//    ) {
-//        this.paymentId = paymentId;
-//        this.order = order;
-//        this.user = user;
-//        this.provider = provider;
-//        this.status = status;
-//        this.totalAmount = totalAmount;
-//        this.pointsToUse = pointsToUse;
-//        this.externalAmount = externalAmount;
-//        this.currency = currency;
-//    }
 
-    // 결제 시도 생성 시점에는 아직 확정 전이라 READY 상태로 시작
-//    public static Payment ready(
-//            String paymentId,
-//            Order order,
-//            User user,
-//            PaymentProvider provider,
-//            long totalAmount,
-//            long pointsToUse,
-//            long externalAmount,
-//            String currency
-//    ) {
-//        return Payment.builder()
-//                .paymentId(paymentId)
-//                .order(order)
-//                .user(user)
-//                .provider(provider)
-//                .status(PaymentStatus.READY)
-//                .totalAmount(totalAmount)
-//                .pointsToUse(pointsToUse)
-//                .externalAmount(externalAmount)
-//                .currency(currency)
-//                .build();
-//    }
+    @Builder
+    private Payment(
+            String paymentId,
+            Order order,
+            User user,
+            PaymentProvider provider,
+            PaymentStatus status,
+            long totalAmount,
+            long pointsToUse,
+            long externalAmount,
+            String currency
+    ) {
+        this.paymentId = paymentId;
+        this.order = order;
+        this.user = user;
+        this.provider = provider;
+        this.status = status;
+        this.totalAmount = totalAmount;
+        this.pointsToUse = pointsToUse;
+        this.externalAmount = externalAmount;
+        this.currency = currency;
+    }
+
+//     결제 시도 생성 시점에는 아직 확정 전이라 READY 상태로 시작
+    public static Payment ready(
+            String paymentId,
+            Order order,
+            User user,
+            PaymentProvider provider,
+            long totalAmount,
+            long pointsToUse,
+            long externalAmount,
+            String currency
+    ) {
+        return Payment.builder()
+                .paymentId(paymentId)
+                .order(order)
+                .user(user)
+                .provider(provider)
+                .status(PaymentStatus.READY)
+                .totalAmount(totalAmount)
+                .pointsToUse(pointsToUse)
+                .externalAmount(externalAmount)
+                .currency(currency)
+                .build();
+    }
 
     // 외부 결제 또는 내부 포인트 결제가 최종 승인할 시에 호출
     public void markPaid(String providerTransactionId) {

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/exception/PaymentException.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/exception/PaymentException.java
@@ -1,0 +1,18 @@
+package sparta.paymentsystemserver.domain.payment.exception;
+
+import lombok.Getter;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
+
+// 결제 도메인 전용 예외의 부모 클래스
+// 결제 생성, 결제 확정, 환불, 웹훅 처리 중 발생하는 예외를
+// ErrorCode 기반으로 일관되게 응답하기 위해 사용합니다
+@Getter
+public class PaymentException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public PaymentException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/repository/PaymentRepository.java
@@ -1,4 +1,13 @@
 package sparta.paymentsystemserver.domain.payment.repository;
 
-public interface PaymentRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import sparta.paymentsystemserver.domain.payment.entity.Payment;
+
+import java.util.Optional;
+
+// 결제 생성 단계에서 사용할 레포지토리
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    // 공개 결제 ID로 조회
+    Optional<Payment> findByPaymentId(String paymentId);
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentService.java
@@ -1,4 +1,96 @@
 package sparta.paymentsystemserver.domain.payment.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.paymentsystemserver.domain.order.entity.Order;
+import sparta.paymentsystemserver.domain.order.entity.OrderStatus;
+import sparta.paymentsystemserver.domain.order.repository.OrderRepository;
+import sparta.paymentsystemserver.domain.payment.dto.CreatePaymentRequest;
+import sparta.paymentsystemserver.domain.payment.dto.CreatePaymentResponse;
+import sparta.paymentsystemserver.domain.payment.entity.Payment;
+import sparta.paymentsystemserver.domain.payment.entity.PaymentProvider;
+import sparta.paymentsystemserver.domain.payment.exception.PaymentException;
+import sparta.paymentsystemserver.domain.payment.repository.PaymentRepository;
+import sparta.paymentsystemserver.domain.user.entity.User;
+import sparta.paymentsystemserver.domain.user.repository.UserRepository;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
+import sparta.paymentsystemserver.global.util.PublicIdGenerator;
+
+
+// 결제 시도 생성과 결제 확정을 담당하는 서비스입니다
+@Service
+@RequiredArgsConstructor
 public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
+    private final PublicIdGenerator publicIdGenerator;
+
+    // 결제 시도 생성 메서드
+    // 이 단계에서는 실제 결제를 확정하지 않고, 프론트가 포트원 결제창을 열기 전에 서버에 READY 상태 결제를 미리 저장하는 용도
+    @Transactional
+    public CreatePaymentResponse createPayment(CreatePaymentRequest request, Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.USER_NOT_FOUND));
+
+        Order order = orderRepository.findByOrderId(request.orderId())
+                .orElseThrow(() -> new PaymentException(ErrorCode.ORDER_NOT_FOUND));
+
+        // 로그인한 사용자의 주문이 아니면 접근 불가
+        if (!order.getUser().getId().equals(userId)) {
+            throw new PaymentException(ErrorCode.ORDER_ACCESS_DENIED);
+        }
+
+        // 결제 대기 상태가 아닌 주문은 결제 생성 불가
+        if (order.getStatus() != OrderStatus.PENDING_PAYMENT) {
+            throw new PaymentException(ErrorCode.ORDER_NOT_PAYABLE);
+        }
+
+        // 프론트 금액과 서버 주문 금액 비교
+        if (!order.getTotalAmount().equals(request.totalAmount())) {
+            throw new PaymentException(ErrorCode.ORDER_AMOUNT_MISMATCH);
+        }
+
+        // 사용 포인트 기본 검증
+        if (request.pointsToUse() < 0 || request.pointsToUse() > order.getTotalAmount()) {
+            throw new PaymentException(ErrorCode.INVALID_POINTS_TO_USE);
+        }
+
+        // 보유 포인트보다 많이 사용하려는 경우
+        if (request.pointsToUse() > user.getPointBalance()) {
+            throw new PaymentException(ErrorCode.INSUFFICIENT_POINTS);
+        }
+
+        long externalAmount = order.getTotalAmount() - request.pointsToUse();
+
+        PaymentProvider provider = externalAmount == 0 ? PaymentProvider.INTERNAL : PaymentProvider.PORTONE;
+
+        String paymentId = publicIdGenerator.generate("PAY");
+
+        Payment payment = Payment.ready(
+                paymentId,
+                order,
+                user,
+                provider,
+                order.getTotalAmount(),
+                request.pointsToUse(),
+                externalAmount,
+                "KRW"
+        );
+
+        paymentRepository.save(payment);
+
+        return new CreatePaymentResponse(
+                payment.getPaymentId(),
+                order.getOrderId(),
+                payment.getTotalAmount(),
+                payment.getPointsToUse(),
+                payment.getExternalAmount(),
+                payment.getStatus().name()
+        );
+    }
+
 }

--- a/src/main/java/sparta/paymentsystemserver/global/exception/ErrorCode.java
+++ b/src/main/java/sparta/paymentsystemserver/global/exception/ErrorCode.java
@@ -15,18 +15,24 @@ public enum ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH003", "만료된 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH004", "Refresh Token이 만료되었습니다. 재로그인 해주세요."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH005", "유효하지 않은 Refresh Token입니다."),
-    PASSWORD_NOT_MATCH(HttpStatus.UNAUTHORIZED, "AUTH006", "비밀번호가 일치하지 않습니다.");
+    PASSWORD_NOT_MATCH(HttpStatus.UNAUTHORIZED, "AUTH006", "비밀번호가 일치하지 않습니다."),
 
 //    사용자 예외 (USER###)
-
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER001", "사용자를 찾을 수 없습니다."),
 
 //    상품 예외 (PROD###)
 
 
 //    주문 예외 (ORD###)
-
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORD001", "주문을 찾을 수 없습니다."),
+    ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ORD002", "본인 주문만 접근할 수 있습니다."),
+    ORDER_NOT_PAYABLE(HttpStatus.BAD_REQUEST, "ORD003", "결제 가능한 주문 상태가 아닙니다."),
+    ORDER_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "ORD004", "주문 금액이 일치하지 않습니다."),
 
 //    결제 예외 (PAY###)
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAY001", "결제 정보를 찾을 수 없습니다."),
+    INVALID_POINTS_TO_USE(HttpStatus.BAD_REQUEST, "PAY002", "사용 포인트 값이 올바르지 않습니다."),
+    INSUFFICIENT_POINTS(HttpStatus.BAD_REQUEST, "PAY003", "보유 포인트가 부족합니다.");
 
 
 //    포인트 예외 (PNT###)

--- a/src/main/java/sparta/paymentsystemserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sparta/paymentsystemserver/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import sparta.paymentsystemserver.domain.auth.exception.AuthException;
+import sparta.paymentsystemserver.domain.payment.exception.PaymentException;
 
 import java.util.List;
 
@@ -48,6 +49,14 @@ public class GlobalExceptionHandler {
 
 
 //    결제 예외 로직 부분
+
+    @ExceptionHandler(PaymentException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handlePaymentException(PaymentException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
 
 
 //    포인트 예외 로직 부분


### PR DESCRIPTION
**작업 설명**
- 결제 초기 생성 단계(payment-init)를 구현했습니다.
사용자가 결제를 시작할 때 서버가 먼저 READY 상태의 결제 시도 레코드를 생성하도록 구성했습니다.
이 단계에서는 실제 결제 확정이나 PortOne 승인 처리는 하지 않고, 주문/사용자/포인트 유효성 검증과 결제 준비 데이터 저장까지만 담당합니다.

**수락 기준**
- 로그인한 사용자는 본인 주문에 대해서만 결제 생성 요청을 할 수 있다.

**추가 정보**
- 실제 PortOne 결제 검증 및 승인 여부 확인은 다음 브랜치 feat/payment-confirm#22 에서 구현 예정입니다.
- 현재 단계는 프론트에서 결제창 호출 전 서버가 결제 시도 정보를 추적할 수 있도록 준비하는 단계입니다.
- GlobalExceptionHandler와 예외 구조는 팀 프로젝트 공통 패턴에 맞춰 ErrorCode 기반으로 연결했습니다.

resolve #21