### PR TITLE
feat: 사용자 정보 조회 구현 #38

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@ build/
 
 .env
 /src/main/resources/application-local.yml
-/src/main/resources/application-prod.yml
-/src/main/resources/logback-spring.xml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ build/
 
 .env
 /src/main/resources/application-local.yml
+/src/main/resources/application-prod.yml
+/src/main/resources/logback-spring.xml
 ### STS ###
 .apt_generated
 .classpath
@@ -37,10 +39,6 @@ out/
 
 ### VS Code ###
 .vscode/
-
-application-local.yml
-application-prod.yml
-logback-spring.xml
 
 ### Mac ###
 .DS_Store

--- a/src/main/java/sparta/paymentsystemserver/domain/user/controller/UserController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/user/controller/UserController.java
@@ -1,11 +1,35 @@
 package sparta.paymentsystemserver.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sparta.paymentsystemserver.domain.auth.dto.LoginUserData;
+import sparta.paymentsystemserver.domain.user.dto.UserResponse;
+import sparta.paymentsystemserver.domain.user.entity.User;
 import sparta.paymentsystemserver.domain.user.service.UserService;
 
 @RestController
+@RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
+
     private final UserService userService;
+
+    // 내 정보 조회: 로그인한 사용자의 정보를 반환
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getMyInfo(
+            @AuthenticationPrincipal LoginUserData loginUserData) {
+        // 토큰에서 꺼낸 userId로 사용자 조회
+        User user = userService.findById(loginUserData.userId());
+        return ResponseEntity.ok(new UserResponse(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getPhone(),
+                user.getCustomerUid()
+        ));
+    }
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/user/dto/UserResponse.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/user/dto/UserResponse.java
@@ -1,4 +1,4 @@
 package sparta.paymentsystemserver.domain.user.dto;
 
-public record UserResponse(Long id, String name, String email, String phone, String customerUid) {
+public record UserResponse(Long userId, String name, String email, String phone, String customerUid) {
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/user/exception/DuplicateEmailException.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/user/exception/DuplicateEmailException.java
@@ -1,0 +1,11 @@
+package sparta.paymentsystemserver.domain.user.exception;
+
+
+import sparta.paymentsystemserver.global.exception.ErrorCode;
+
+// 이메일 중복 시 발생하는 예외 (회원가입 시 이미 존재하는 이메일로 가입 시도할 때)
+public class DuplicateEmailException extends UserException {
+    public DuplicateEmailException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/user/exception/UserException.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/user/exception/UserException.java
@@ -1,0 +1,14 @@
+package sparta.paymentsystemserver.domain.user.exception;
+
+import lombok.Getter;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
+
+@Getter
+public abstract class UserException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public UserException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package sparta.paymentsystemserver.domain.user.exception;
+
+import sparta.paymentsystemserver.global.exception.ErrorCode;
+
+public class UserNotFoundException extends UserException {
+
+    public UserNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/user/service/UserService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/user/service/UserService.java
@@ -7,7 +7,10 @@ import org.springframework.transaction.annotation.Transactional;
 import sparta.paymentsystemserver.domain.user.dto.UserRequest;
 import sparta.paymentsystemserver.domain.user.dto.UserResponse;
 import sparta.paymentsystemserver.domain.user.entity.User;
+import sparta.paymentsystemserver.domain.user.exception.DuplicateEmailException;
+import sparta.paymentsystemserver.domain.user.exception.UserNotFoundException;
 import sparta.paymentsystemserver.domain.user.repository.UserRepository;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -16,12 +19,16 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
+    // 회원가입: 이메일 중복 확인 후 사용자 저장
     @Transactional
     public UserResponse save(UserRequest requestDto) {
+
+        // 이메일 중복 검사: 이미 존재하는 이메일 예외 발생
         if (userRepository.existsByEmail(requestDto.getEmail())) {
-            throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+            throw new DuplicateEmailException(ErrorCode.DUPLICATE_EMAIL);
         }
 
+        // 비밀번호 암호화 후 사용자 생성
         User user = new User(
                 requestDto.getName(),
                 requestDto.getEmail(),
@@ -30,6 +37,7 @@ public class UserService {
                 requestDto.getCustomerUid()
         );
 
+        // 사용자 저장 후 응답 DTO 반환
         User savedUser = userRepository.save(user);
         return new UserResponse(
                 savedUser.getId(),
@@ -40,10 +48,19 @@ public class UserService {
         );
     }
 
+    // 이메일로 사용자 조회 -> 없으면 UserNotFoundException 발생
     @Transactional(readOnly = true)
     public User findByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow(
-                () -> new IllegalArgumentException("존재하지 않은 유저입니다.")
+                () -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND)
+        );
+    }
+
+    // ID 로 사용자 조회 -> 없으면 UserNotFoundException 발생
+    @Transactional(readOnly = true)
+    public User findById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+                () -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND)
         );
     }
 }

--- a/src/main/java/sparta/paymentsystemserver/global/exception/ErrorCode.java
+++ b/src/main/java/sparta/paymentsystemserver/global/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
 
 //    사용자 예외 (USER###)
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER001", "사용자를 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "USER002", "이미 존재하는 이메일입니다."),
 
 //    상품 예외 (PROD###)
     PRODUCT_OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "PROD001", "재고가 부족합니다"),

--- a/src/main/java/sparta/paymentsystemserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sparta/paymentsystemserver/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import sparta.paymentsystemserver.domain.auth.exception.AuthException;
 import sparta.paymentsystemserver.domain.product.exception.ProductException;
 import sparta.paymentsystemserver.domain.payment.exception.PaymentException;
+import sparta.paymentsystemserver.domain.user.exception.UserException;
 
 import java.util.List;
 
@@ -40,8 +41,15 @@ public class GlobalExceptionHandler {
                 .status(errorCode.getStatus())
                 .body(ApiResponse.fail(errorCode));
     }
-//    사용자 예외 로직 부분
 
+    //    사용자 예외 로직 부분
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleUserException(UserException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
 
 //    상품 예외 로직 부분
 


### PR DESCRIPTION
- UserException, UserNotFoundException, DuplicateEmailException 예외 클래스 추가
- ErrorCode에 USER_NOT_FOUND, DUPLICATE_EMAIL 추가
- GlobalExceptionHandler에 UserException 처리 추가
- UserService에 findById 메서드 추가
- UserController에 GET /api/users/me API 추가
- UserResponse의 id → userId로 변경
- .gitignore 수정