### PR TITLE
feat: 웹훅 처리 구현 및 PublicIdGenerator TSID 기반으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'com.github.f4b6a3:tsid-creator:5.2.6'
     //jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/controller/WebhookController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/controller/WebhookController.java
@@ -1,5 +1,25 @@
 package sparta.paymentsystemserver.domain.payment.controller;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import sparta.paymentsystemserver.domain.payment.dto.PortOneWebhookRequest;
+import sparta.paymentsystemserver.domain.payment.dto.WebhookResponse;
+import sparta.paymentsystemserver.domain.payment.service.WebhookService;
+
 // 포트원 웹훅 수신 API입니다
+// 외부 포트원 서버가 직접 호출하기 때문에 jwt 인증 없이 접근 가능해야 됨
+@RestController
+@RequestMapping("/api/webhooks/payments")
+@RequiredArgsConstructor
 public class WebhookController {
+
+    private final WebhookService webhookService;
+
+    @PostMapping
+    public WebhookResponse receiveWebhook(
+            @RequestHeader("webhook-id") String webhookId,
+            @RequestBody PortOneWebhookRequest request
+    ) {
+        return webhookService.processWebhook(webhookId, request);
+    }
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/dto/PortOneWebhookRequest.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/dto/PortOneWebhookRequest.java
@@ -1,5 +1,9 @@
 package sparta.paymentsystemserver.domain.payment.dto;
 
-// 포트원 웹훅 수신 페이로드
-public record PortOneWebhookRequest() {
+// 포트원 웹훅 요청 dto
+// 웹훅 페이로드는 최종 신뢰 대상이 아니니까 최소 필드만 받음 실제 최종 결제 상태는 서버가 paymentId로 포트원 재조회 후에 판단
+public record PortOneWebhookRequest(
+        String paymentId,
+        String status
+) {
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/dto/WebhookResponse.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/dto/WebhookResponse.java
@@ -1,5 +1,8 @@
 package sparta.paymentsystemserver.domain.payment.dto;
 
-// 웹훅 수신 응답 dto
-public record WebhookResponse() {
+// 웹훅 처리 결과 응답 dto
+public record WebhookResponse(
+        boolean success,
+        String message
+) {
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/entity/PaymentWebhookEvent.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/entity/PaymentWebhookEvent.java
@@ -20,7 +20,7 @@ public class PaymentWebhookEvent extends BaseEntity {
     private Long id;
 
     // 포트원이 보낸 웹훅 고유 Id 중복 수신 방지 키
-    @Column(nullable = false, unique = false, length = 60)
+    @Column(nullable = false, unique = true, length = 60)
     private String webhookId;
 
     // 이 이벤트가 가리키는 내부 페이먼트아이디

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/repository/PaymentWebhookEventRepository.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/repository/PaymentWebhookEventRepository.java
@@ -1,4 +1,16 @@
 package sparta.paymentsystemserver.domain.payment.repository;
 
-public interface PaymentWebhookEventRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import sparta.paymentsystemserver.domain.payment.entity.PaymentWebhookEvent;
+
+import java.util.Optional;
+
+// 웹훅 이벤트 저장소. 같은 webhookId가 여러 번 들어오더라도 한 번만 처리하기 위해 사용함
+public interface PaymentWebhookEventRepository extends JpaRepository<PaymentWebhookEvent, Long> {
+
+    // webhookId 기준 단건 조회
+    Optional<PaymentWebhookEvent> findByWebhookId(String webhookId);
+
+    // webhookId 중복 존재 여부 확인
+    boolean existsByWebhookId(String webhookId);
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentService.java
@@ -111,7 +111,27 @@ public class PaymentService {
             throw new PaymentException(ErrorCode.ORDER_ACCESS_DENIED);
         }
 
-        // 이미 결제 완료 상태라면 멱등하게 그대로 성공 응답을 반환
+        return confirmPaymentInternal(payment);
+    }
+
+
+    // 내부 공용 결제 확정 메서드
+    // 클라이언트 쪽의 confirm과 webhook confirm이 같은 로직을 재사용하도록 분리
+    @Transactional
+    public PaymentResultResponse confirmPaymentByWebhook(String paymentId) {
+        Payment payment = paymentRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        return confirmPaymentInternal(payment);
+    }
+
+
+
+    // 실제 결제 확정 공통 로직
+    // 결제 상태, 포트원 조회 결과, 금액 일치 여부를 검증한 뒤에 최족 확정
+    private PaymentResultResponse confirmPaymentInternal(Payment payment) {
+
+        // 이미 결제 완료된 상태라면 멱등하게 그대로 성공 응답 반환
         if (payment.getStatus() == PaymentStatus.PAID) {
             return new PaymentResultResponse(
                     true,
@@ -121,12 +141,12 @@ public class PaymentService {
             );
         }
 
-        // READY 상태가 아닌 결제는 확정 대상이 아님
+        // READY 상태만 확정 가능
         if (payment.getStatus() != PaymentStatus.READY) {
             throw new PaymentException(ErrorCode.PAYMENT_CONFIRM_NOT_ALLOWED);
         }
 
-        // 내부 포인트 전액 결제는 외부 PortOne 호출 없이 바로 성공 처리할 수 있게 함
+        // 내부 포인트 전액 결제는 외부 조회 없이 바로 성공 처리
         if (payment.getProvider() == PaymentProvider.INTERNAL) {
             payment.markPaid("INTERNAL");
             payment.getOrder().complete();
@@ -139,22 +159,20 @@ public class PaymentService {
             );
         }
 
-        // 외부 포트원 결제는 서버가 직접 결제 조회를 수행
-        PortOnePaymentClient.PortOnePaymentInfo paymentInfo = portOnePaymentClient.getPayment(paymentId);
+        // 포트원 재조회
+        PortOnePaymentClient.PortOnePaymentInfo paymentInfo =
+                portOnePaymentClient.getPayment(payment.getPaymentId());
 
-        // 실제 포트원 응답 기준으로 결제 성공 상태인지 확인
         if (!paymentInfo.isPaid()) {
             payment.markFailed("PortOne 결제 상태가 PAID가 아닙니다.");
             throw new PaymentException(ErrorCode.PAYMENT_VERIFICATION_FAILED);
         }
 
-        // 포트원 승인 금액과 서버가 계산한 외부 결제 금액이 정확히 일치해야 함
         if (paymentInfo.amount() != payment.getExternalAmount()) {
             payment.markFailed("PortOne 승인 금액과 서버 계산 금액이 일치하지 않습니다.");
             throw new PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
 
-        // 모든 검증이 끝난 뒤에만 최종 결제 완료 처리
         payment.markPaid(paymentInfo.transactionId());
         payment.getOrder().complete();
 

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookService.java
@@ -1,4 +1,51 @@
 package sparta.paymentsystemserver.domain.payment.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.paymentsystemserver.domain.payment.dto.PortOneWebhookRequest;
+import sparta.paymentsystemserver.domain.payment.dto.WebhookResponse;
+import sparta.paymentsystemserver.domain.payment.entity.PaymentWebhookEvent;
+import sparta.paymentsystemserver.domain.payment.repository.PaymentWebhookEventRepository;
+
+// 포트원 웹훅 처리 서비스
+// webhook-id 기준 멱등 처리과 페이로드가 아니라 paymentId 기반 포트원 재조회 결과를 신뢰
+@Service
+@RequiredArgsConstructor
 public class WebhookService {
+
+    private final PaymentWebhookEventRepository paymentWebhookEventRepository;
+    private final PaymentService paymentService;
+
+    @Transactional
+    public WebhookResponse processWebhook(String webhookId, PortOneWebhookRequest request) {
+
+        // 이미 같은 webhookId를 처리한 적이 있으면 중복 웹훅으로 간주
+        if (paymentWebhookEventRepository.existsByWebhookId(webhookId)) {
+            return new WebhookResponse(true, "이미 처리된 웹훅입니다.");
+        }
+
+        // 원본 payload를 문자열로 간단하게 저장
+        String rawPayload = "paymentId=" + request.paymentId() + ", status=" + request.status();
+
+        PaymentWebhookEvent event = PaymentWebhookEvent.received(
+                webhookId,
+                request.paymentId(),
+                request.status(),
+                rawPayload
+        );
+
+        paymentWebhookEventRepository.save(event);
+
+        try {
+            // 웹훅 payload를 그대로 믿지 않고 paymentId 기준 재조회 후 공통 confirm 로직 수행
+            paymentService.confirmPaymentByWebhook(request.paymentId());
+
+            event.markProcessed();
+            return new WebhookResponse(true, "웹훅 처리가 완료되었습니다.");
+        } catch (Exception e) {
+            event.markFailed(e.getMessage());
+            return new WebhookResponse(false, "웹훅 처리에 실패했습니다.");
+        }
+    }
 }

--- a/src/main/java/sparta/paymentsystemserver/global/util/PublicIdGenerator.java
+++ b/src/main/java/sparta/paymentsystemserver/global/util/PublicIdGenerator.java
@@ -1,35 +1,15 @@
 package sparta.paymentsystemserver.global.util;
 
+import com.github.f4b6a3.tsid.TsidCreator;
 import org.springframework.stereotype.Component;
 
-import java.security.SecureRandom;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
 // 외부에 노출되는 공개 식별자를 생성하는 유틸리티
-// 사람이 읽을 수 있는 규칙 유지, 충돌 가능성 낮추기 위해 시간 문자열이랑 짧은 난수 조합
+// TSID 기반으로 정렬 가능한 고유 id를 만들고 도메인별로 prefix를 붙여서 사용합니다
 @Component
 public class PublicIdGenerator {
 
-    private static final String ALPHANUMERIC = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-
-    private final SecureRandom secureRandom = new SecureRandom();
-
-
-    // 접두사 + 시각 + 난수 조합으로 공개 ID를 생성
-    // 예를 들어 - USR-... ORD-... PAY-...
     public String generate(String prefix) {
-        return prefix + "-" + LocalDateTime.now().format(FORMATTER) + "-" + randomPart(10);
-    }
-
-    // 난수 구간
-    private String randomPart(int length) {
-        StringBuilder builder = new StringBuilder(length);
-        for (int index = 0; index < length; index++) {
-            builder.append(ALPHANUMERIC.charAt(secureRandom.nextInt(ALPHANUMERIC.length())));
-        }
-        return builder.toString();
+        return prefix + "-" + TsidCreator.getTsid();
     }
 
 }

--- a/src/main/resources/client-api-config.yml
+++ b/src/main/resources/client-api-config.yml
@@ -58,8 +58,8 @@ api:
               description: 로그인한 사용자 이메일
 
     register:
-      url:
-      method:
+      url: /api/auth/signup
+      method: POST
       description: 회원가입
       request:
         fields:
@@ -88,8 +88,8 @@ api:
               description: 에러 메시지 (실패 시)
 
     get-current-user:
-      url:
-      method:
+      url: /api/users/me
+      method: GET
       description: 현재 로그인한 사용자 정보 조회
       response:
         body:
@@ -123,8 +123,8 @@ api:
     # 상품 & 주문 (Product & Order)
     # ========================================
     list-products:
-      url:
-      method:
+      url: /api/products
+      method: GET
       description: 상품 목록 조회
       response:
         body:
@@ -223,8 +223,8 @@ api:
     # 결제 (Payment)
     # ========================================
     create-payment:
-      url:
-      method:
+      url: /api/payments
+      method: POST
       description: 결제 시작 요청 (DB에 PENDING 상태로 등록, PortOne SDK 호출 전에 먼저 호출)
       request:
         fields:
@@ -254,14 +254,14 @@ api:
             - name: status
               type: string
               required: false
-              description: 결제 상태 (PENDING)
+              description: 결제 상태 (READY)
 
     confirm-payment:
-      url:
-      method:
+      url: /api/payments/{paymentId}/confirm
+      method: POST
       description: 결제 확정 (PortOne 결제 검증 및 주문 상태 업데이트)
       pathParams:
-        - name:
+        - name: paymentId
           description: 결제 ID
       response:
         body:
@@ -270,6 +270,10 @@ api:
               type: boolean
               required: true
               description: 확정 성공 여부
+            - name: paymentId
+              type: string
+              required: true
+              description: 결제 생성 단계에서 서버가 발급한 공개 결제 ID
             - name: orderId
               type: string
               required: false


### PR DESCRIPTION
**작업 설명**
포트원 웹훅 수신 및 결제 회수 처리 로직을 구현했습니다. 엔드포인트를 추가하고 webhook-id 기준 멱등 처리 후에 paymentId로 포트원 결제를 재조회해서 기존 결제 확정 로직을 재사용하도록 수정했습니다.
추가로 공개 식별자 생성 유틸리티인 PublicIdGenerator를 TSID 기반 의존성 추가해서 변경했습니다.

**수락 기준**
- 이미 처리된 결제는 멱등하게 정상 응답한다

**추가 정보**
- 이번 브랜치에서는 환불 처리 로직은 포함하지 않았고 다음 브랜치에서 진행 예정입니다