### PR TITLE
feat: 결제 환불 API 구현

### DIFF
--- a/src/main/java/sparta/paymentsystemserver/domain/payment/controller/PaymentController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/controller/PaymentController.java
@@ -5,10 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import sparta.paymentsystemserver.domain.auth.dto.LoginUserData;
+import sparta.paymentsystemserver.domain.payment.dto.CancelPaymentRequest;
 import sparta.paymentsystemserver.domain.payment.dto.CreatePaymentRequest;
 import sparta.paymentsystemserver.domain.payment.dto.CreatePaymentResponse;
 import sparta.paymentsystemserver.domain.payment.dto.PaymentResultResponse;
 import sparta.paymentsystemserver.domain.payment.service.PaymentService;
+import sparta.paymentsystemserver.domain.payment.service.RefundService;
 
 // 결제를 생성하고 확정, 환불을 하는 API입니다
 @RestController
@@ -17,6 +19,7 @@ import sparta.paymentsystemserver.domain.payment.service.PaymentService;
 public class PaymentController {
 
     private final PaymentService paymentService;
+    private final RefundService refundService;
 
     // 결제 시도 생성 API JWT에서 꺼낸 현재 로그인 사용자 정보 사용
     @PostMapping
@@ -34,6 +37,16 @@ public class PaymentController {
             @AuthenticationPrincipal LoginUserData loginUserData
     ) {
         return paymentService.confirmPayment(paymentId, loginUserData.userId());
+    }
+
+    // 전액 환불 요청 API, 클라이언트는 환불 요청만 보내고 실제 포트원 결제 취소와 내부 환불 상태 반영은 서버가 책임진다
+    @PostMapping("/{paymentId}/cancel")
+    public PaymentResultResponse cancelPayment(
+            @PathVariable String paymentId,
+            @AuthenticationPrincipal LoginUserData loginUserData,
+            @RequestBody CancelPaymentRequest request
+    ) {
+        return refundService.cancelPayment(paymentId, loginUserData.userId(), request.reason());
     }
 
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/repository/RefundRepository.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/repository/RefundRepository.java
@@ -1,4 +1,18 @@
 package sparta.paymentsystemserver.domain.payment.repository;
 
-public interface RefundRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import sparta.paymentsystemserver.domain.payment.entity.Refund;
+
+import java.util.Optional;
+
+// 환불 이력을 저장합니다. 하나의 결제에 대한 환불은 최대 1건 기준 조회
+public interface RefundRepository extends JpaRepository<Refund, Long> {
+
+    // 결제id 기준으로 환불 이력 조회
+    Optional<Refund> findByPaymentId(Long paymentId);
+
+    // 이미 환불 이력이 존재하는지 확인
+    boolean existsByPaymentId(Long paymentId);
+
+    Optional<Refund> findByRefundId(String refundId);
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/RefundService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/RefundService.java
@@ -1,4 +1,95 @@
 package sparta.paymentsystemserver.domain.payment.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.paymentsystemserver.domain.payment.dto.PaymentResultResponse;
+import sparta.paymentsystemserver.domain.payment.entity.*;
+import sparta.paymentsystemserver.domain.payment.exception.PaymentException;
+import sparta.paymentsystemserver.domain.payment.repository.PaymentRepository;
+import sparta.paymentsystemserver.domain.payment.repository.RefundRepository;
+import sparta.paymentsystemserver.global.client.PortOnePaymentClient;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
+import sparta.paymentsystemserver.global.util.PublicIdGenerator;
+
+
+@Service
+@RequiredArgsConstructor
 public class RefundService {
+
+    private final PaymentRepository paymentRepository;
+    private final RefundRepository refundRepository;
+    private final PortOnePaymentClient portOnePaymentClient;
+    private final PublicIdGenerator publicIdGenerator;
+
+    @Transactional
+    public PaymentResultResponse cancelPayment(String paymentId, Long userId, String reason) {
+
+        Payment payment = paymentRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        // 본인 결제만 환불 가능
+        if (!payment.getUser().getId().equals(userId)) {
+            throw new PaymentException(ErrorCode.ORDER_ACCESS_DENIED);
+        }
+
+        // 이미 환불된 경우 멱등 처리
+        if (payment.getStatus() == PaymentStatus.REFUNDED) {
+            return new PaymentResultResponse(
+                    true,
+                    payment.getPaymentId(),
+                    payment.getOrder().getOrderId(),
+                    payment.getStatus().name()
+            );
+        }
+
+        // 결제 완료 상태만 환불 가능
+        if (payment.getStatus() != PaymentStatus.PAID) {
+            throw new PaymentException(ErrorCode.REFUND_NOT_ALLOWED);
+        }
+
+        // 동일 결제 환불 이력 중복 방지
+        if (refundRepository.existsByPaymentId(payment.getId())) {
+            throw new PaymentException(ErrorCode.REFUND_ALREADY_PROCESSED);
+        }
+
+        String providerRefundId = "INTERNAL";
+        long refundAmount = payment.getExternalAmount();
+
+        // PortOne 결제인 경우 외부 취소 API 호출
+        if (payment.getProvider() == PaymentProvider.PORTONE) {
+            PortOnePaymentClient.PortOneRefundInfo refundInfo =
+                    portOnePaymentClient.cancelPayment(payment.getPaymentId(), reason);
+
+            if (!refundInfo.isCancelled()) {
+                throw new PaymentException(ErrorCode.REFUND_PROCESS_FAILED);
+            }
+
+            providerRefundId = refundInfo.refundId();
+            refundAmount = refundInfo.cancelledAmount();
+        }
+
+        // 환불은 단순 상태 변경이 아니라서 별도 도메인 이력으로 관리한다
+        Refund refund = Refund.create(
+                publicIdGenerator.generate("REF"),
+                payment,
+                refundAmount,
+                reason,
+                RefundStatus.COMPLETED,
+                providerRefundId
+        );
+
+        refundRepository.save(refund);
+
+        // 외부 환불이 정상적으로 완료되면 내부 결제 상태와 주문상태도 함께 REFUNDED로 변경함
+        payment.markRefunded();
+        payment.getOrder().refund();
+
+        return new PaymentResultResponse(
+                true,
+                payment.getPaymentId(),
+                payment.getOrder().getOrderId(),
+                payment.getStatus().name()
+        );
+    }
 }

--- a/src/main/java/sparta/paymentsystemserver/global/client/PortOnePaymentClient.java
+++ b/src/main/java/sparta/paymentsystemserver/global/client/PortOnePaymentClient.java
@@ -7,6 +7,9 @@ public interface PortOnePaymentClient {
     // paymentId 기준으로 포트뭔 결제 단건 조회
     PortOnePaymentInfo getPayment(String paymentId);
 
+    // paymentId 기준으로 전액 환불 요청
+    PortOneRefundInfo cancelPayment(String paymentId, String reason);
+
     record PortOnePaymentInfo(
             String paymentId,
             String transactionId,
@@ -16,6 +19,21 @@ public interface PortOnePaymentClient {
         // 포트원 응답이 결제 완료 상태인지 판단하는 메서드
         public boolean isPaid() {
             return "PAID".equalsIgnoreCase(status) || "SUCCEEDED".equalsIgnoreCase(status);
+        }
+    }
+
+    // 포트원 환불 응답 중 서버가 필요한 정보 담음
+    record PortOneRefundInfo(
+            String paymentId,
+            String refundId,
+            String status,
+            long cancelledAmount
+    ) {
+        // PortOne 응답이 환불 완료 상태인지 판단
+        public boolean isCancelled() {
+            return "CANCELLED".equalsIgnoreCase(status)
+                    || "PARTIAL_CANCELLED".equalsIgnoreCase(status)
+                    || "REFUNDED".equalsIgnoreCase(status);
         }
     }
 }

--- a/src/main/java/sparta/paymentsystemserver/global/client/PortOnePaymentClientImpl.java
+++ b/src/main/java/sparta/paymentsystemserver/global/client/PortOnePaymentClientImpl.java
@@ -33,7 +33,7 @@ public class PortOnePaymentClientImpl implements PortOnePaymentClient {
                     .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                     .build();
 
-            // PortOne 결제 단건 조회
+            // PortOne 결제 단건 조회 서버가 결제 확정 전에 실제 포트원 상태와 금액을 직접 검증 위해서 사용
             Map<String, Object> body = restClient.get()
                     .uri(uriBuilder -> uriBuilder
                             .path("/payments/{paymentId}")
@@ -42,7 +42,7 @@ public class PortOnePaymentClientImpl implements PortOnePaymentClient {
                     .retrieve()
                     .body(new ParameterizedTypeReference<>() {
                     });
-
+            // 포트원 응답에서 서버 내부 검증에 필요한 값만 확인
             return new PortOnePaymentInfo(
                     stringValue(body, "paymentId", paymentId),
                     firstNonBlank(
@@ -53,8 +53,50 @@ public class PortOnePaymentClientImpl implements PortOnePaymentClient {
                     firstLong(body, "amount", "totalAmount", "paidAmount")
             );
         } catch (RestClientResponseException e) {
+            // 포트원 응답 자체가 실패하거나 예외 발생시 결제 검증 실패로 보냄
             throw new PaymentException(ErrorCode.PAYMENT_VERIFICATION_FAILED);
         }
+    }
+
+    // paymentId 기준으로 포트원 전액 환불을 요청 사유 없으면 기본 메시지 넣어서 요청
+    @Override
+    public PortOneRefundInfo cancelPayment(String paymentId, String reason) {
+        try {
+            Map<String, Object> body = buildRestClient()
+                    .post()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/payments/{paymentId}/cancel")
+                            .queryParam("storeId", portOneProperties.getStore().getId())
+                            .build(paymentId))
+                    .body(Map.of(
+                            "reason", reason == null ? "사용자 요청 환불" : reason
+                    ))
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<>() {
+                    });
+
+            return new PortOneRefundInfo(
+                    stringValue(body, "paymentId", paymentId),
+                    firstNonBlank(
+                            stringValue(body, "refundId", null),
+                            stringValue(body, "txId", null),
+                            stringValue(body, "transactionId", null)
+                    ),
+                    stringValue(body, "status", "UNKNOWN"),
+                    firstLong(body, "cancelledAmount", "amount")
+            );
+        } catch (RestClientResponseException exception) {
+            throw new PaymentException(ErrorCode.REFUND_PROCESS_FAILED);
+        }
+    }
+
+    // PortOne API 호출용 RestClient를 공통 설정과 함께 생성
+    private RestClient buildRestClient() {
+        return restClientBuilder
+                .baseUrl(portOneProperties.getApi().getBaseUrl())
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "PortOne " + portOneProperties.getApi().getSecret())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
     }
 
     // 응답 본문(json)에서 문자열 값을 읽는 보조 메서드
@@ -64,26 +106,43 @@ public class PortOnePaymentClientImpl implements PortOnePaymentClient {
     }
 
 
-    // amount.total 같은 중첩 응답까지 포함해서 가장 먼저 찾은 수자 값을 반환
+    // 후보 key 순서대로 확인하면서 포트원 응답에서 첫 번째로 읽을 수 있는 숫자값을 반환
+    // 응답 구조가 환경에 따라서 다를 수 있어서 후보기를 유연하게 검사하기 위해서 사용
     private long firstLong(Map<String, Object> body, String... keys) {
         for (String key : keys) {
-            Object value = body == null ? null : body.get(key);
-
-            if (value instanceof Number number) {
-                return number.longValue();
-            }
-
-            if (value instanceof Map<?, ?> nestedMap) {
-                Object total = nestedMap.get("total");
-                if (total instanceof Number number) {
-                    return number.longValue();
-                }
+            Long value = extractLong(body, key);
+            if (value != null) {
+                return value;
             }
         }
         return 0L;
     }
 
+    // 단일 key 기준으로 숫자값을 읽는다 값이 바로 숫자로 오는 경우랑 중첩 구조 모두 처리
+    // 읽을 수 있는 숫자가 없으면 null 반환
+    private Long extractLong(Map<String, Object> body, String key) {
+        Object value = body == null ? null : body.get(key);
+
+        // amount: 1000처럼 숫자가 직접 들어온 경우
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+
+        // 중첩 객체가 아닌 경우는 처리할 수 없음
+        if (!(value instanceof Map<?,?> nestedMap)) {
+            return null;
+        }
+
+        // 중첩 객체 안의 total 값을 우선적으로 확인
+        Object total = nestedMap.get("total");
+        if (!(total instanceof Number number)) {
+            return null;
+        }
+        return number.longValue();
+    }
+
     // 여러 후보 문자열 중 비어있지 않은 첫 번째 값을 반환
+    // 포트원 응답 필드명이 다를 수도 있으니까 후보 키를 순서대로 검사할 때 사용함
     private String firstNonBlank(String... candidates) {
         for (String candidate : candidates) {
             if (candidate != null && !candidate.isBlank()) {

--- a/src/main/java/sparta/paymentsystemserver/global/exception/ErrorCode.java
+++ b/src/main/java/sparta/paymentsystemserver/global/exception/ErrorCode.java
@@ -40,6 +40,9 @@ public enum ErrorCode {
     PAYMENT_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "PAY004", "PortOne 결제 검증에 실패했습니다."),
     PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAY005", "결제 승인 금액이 서버 계산 금액과 일치하지 않습니다."),
     PAYMENT_CONFIRM_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "PAY006", "확정할 수 없는 결제 상태입니다."),
+    REFUND_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "PAY007", "이미 환불 완료된 결제입니다."),
+    REFUND_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "PAY008", "환불할 수 없는 결제 상태입니다."),
+    REFUND_PROCESS_FAILED(HttpStatus.BAD_REQUEST, "PAY009", "PortOne 환불 처리에 실패했습니다."),
 
 
 //    포인트 예외 (PNT###)

--- a/src/main/resources/client-api-config.yml
+++ b/src/main/resources/client-api-config.yml
@@ -223,7 +223,7 @@ api:
     create-payment:
       url: /api/payments
       method: POST
-      description: 결제 시작 요청 (DB에 PENDING 상태로 등록, PortOne SDK 호출 전에 먼저 호출)
+      description: 결제 시작 요청 (DB에 READY 상태로 등록, PortOne SDK 호출 전에 먼저 호출)
       request:
         fields:
           - name: orderId
@@ -282,11 +282,11 @@ api:
               description: 변경된 주문 상태
 
     cancel-payment:
-      url:
-      method:
+      url: /api/payments/{paymentId}/cancel
+      method: POST
       description: 결제 취소/환불 (PortOne 결제 취소 및 주문 상태 업데이트)
       pathParams:
-        - name:
+        - name: paymentId
           description: 결제 ID
       request:
         fields:


### PR DESCRIPTION
**작업 설명**
전액 환불 API를 구현하고 프론트 연동 계약을 함께 정리했습니다.
사용자가 환불 요청을 보내면 서버가 본인 결제 여부와 결제 상태를 검증한 뒤, 포트원 결제 취소 api를 호출하고 refund 이력을 저장하도록 구성했습니다

**수락 기준**
- pi/payments/{paymentId}/cancel 엔드포인트가 존재한다.
- 로그인한 사용자는 본인 결제에 대해서만 환불 요청할 수 있다.
- PAID 상태인 결제만 환불할 수 있다.
- 이미 REFUNDED 상태인 결제는 멱등하게 정상 응답한다.
- 동일 결제에 대해 중복 환불 이력이 생성되지 않는다.
- PortOne 결제인 경우 서버가 PortOne 결제 취소 API를 호출한다.

**추가 정보**
- 현재 환불 로직은 전액 환불입니다