### PR TITLE
feat: Google-OAuth2 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Google-OAuth
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/sparta/paymentsystemserver/domain/auth/dto/OAuthUserInfo.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/auth/dto/OAuthUserInfo.java
@@ -1,0 +1,30 @@
+package sparta.paymentsystemserver.domain.auth.dto;
+
+import java.util.Map;
+
+/**
+ * 구글이 보내주는 JSON 데이터
+ * {
+ *   "sub"                        // 구글 고유 사용자 ID
+ *   "name"
+ *   "given_name"
+ *   "family_name"
+ *   "email"
+ *   "email_verified"
+ *   "picture"                    // 프로필 사진 URL
+ * }
+ */
+
+public record OAuthUserInfo(
+        String email,
+        String name,
+        String providerId
+) {
+    public static OAuthUserInfo from(Map<String, Object> attributes) {
+        return new OAuthUserInfo(
+                (String) attributes.get("email"),
+                (String) attributes.get("name"),
+                (String) attributes.get("sub")
+        );
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/auth/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,65 @@
+package sparta.paymentsystemserver.domain.auth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import sparta.paymentsystemserver.domain.user.entity.User;
+import sparta.paymentsystemserver.domain.user.repository.UserRepository;
+import sparta.paymentsystemserver.global.jwt.JwtUtil;
+import sparta.paymentsystemserver.global.redis.RedisRefreshTokenUtil;
+
+import java.io.IOException;
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+    private final RedisRefreshTokenUtil redisRefreshTokenUtil;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+//        DefaultOAuth2User가 주입된 상태
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        String email = (String) oAuth2User.getAttributes().get("email");
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalStateException("유저를 찾을 수 없습니다."));
+
+        String accessToken = jwtUtil.createAccessToken(user.getId(), user.getEmail());
+        String refreshToken = jwtUtil.createRefreshToken(user.getEmail());
+
+        redisRefreshTokenUtil.save(user.getId(), refreshToken, jwtUtil.getRefreshTokenExpiration());
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(Duration.ofDays(7))
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+//        프론트에서 토큰을 꺼내 저장
+        String redirectUrl = "https://test.2run2run.click/pages/oauth2-callback.html"
+                + "?token=" + accessToken;
+
+        log.info("[OAuth 로그인 성공] email: {}, userId: {}", email, user.getId());
+
+//        리다이렉트 수행
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/auth/handler/OAuth2SuccessHandler.java
@@ -12,7 +12,9 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import sparta.paymentsystemserver.domain.user.entity.User;
+import sparta.paymentsystemserver.domain.user.exception.UserNotFoundException;
 import sparta.paymentsystemserver.domain.user.repository.UserRepository;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
 import sparta.paymentsystemserver.global.jwt.JwtUtil;
 import sparta.paymentsystemserver.global.redis.RedisRefreshTokenUtil;
 
@@ -36,7 +38,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String email = (String) oAuth2User.getAttributes().get("email");
 
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalStateException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         String accessToken = jwtUtil.createAccessToken(user.getId(), user.getEmail());
         String refreshToken = jwtUtil.createRefreshToken(user.getEmail());

--- a/src/main/java/sparta/paymentsystemserver/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,67 @@
+package sparta.paymentsystemserver.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.paymentsystemserver.domain.auth.dto.OAuthUserInfo;
+import sparta.paymentsystemserver.domain.user.entity.AuthProvider;
+import sparta.paymentsystemserver.domain.user.entity.User;
+import sparta.paymentsystemserver.domain.user.repository.UserRepository;
+import sparta.paymentsystemserver.global.util.PublicIdGenerator;
+
+import java.util.Collections;
+
+// Spring Security가 구글 인증 완료 후 자동으로 이 메서드를 호출
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+    private final PublicIdGenerator publicIdGenerator;
+
+    @Transactional
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+//        Spring이 기본으로 제공하는 구글 정보 조회 클래스
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+
+//        구글 서버에 요청해서 사용자 정보(JSON) 가져오는 것
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        OAuthUserInfo userInfo = OAuthUserInfo.from(oAuth2User.getAttributes());
+
+        userRepository.findByEmail(userInfo.email())
+                .orElseGet(() -> registerNewUser(userInfo));
+
+        log.info("[OAuth 로그인] email: {}", userInfo.email());
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                oAuth2User.getAttributes(),
+                "email"
+        );
+    }
+
+    private User registerNewUser(OAuthUserInfo userInfo) {
+        User user = new User(
+                userInfo.name(),
+                userInfo.email(),
+                "",
+                publicIdGenerator.generate("USR"),
+                AuthProvider.GOOGLE,
+                userInfo.providerId()
+        );
+
+        log.info("[OAuth 신규 회원가입] email: {}", userInfo.email());
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/user/entity/AuthProvider.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/user/entity/AuthProvider.java
@@ -1,0 +1,6 @@
+package sparta.paymentsystemserver.domain.user.entity;
+
+public enum AuthProvider {
+    LOCAL,
+    GOOGLE
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/user/entity/User.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/user/entity/User.java
@@ -33,8 +33,16 @@ public class User extends BaseEntity {
     private String email;
 
     // 비밀번호
-    @Column(nullable = false)
+    // OAuth 도입으로 필수 제거
+    @Column
     private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AuthProvider provider = AuthProvider.LOCAL;
+
+    @Column
+    private String providerId;
 
     // PortOne 빌링 고객 식별자
     @Column(nullable = false)
@@ -63,6 +71,17 @@ public class User extends BaseEntity {
         this.password = password;
         this.phone = phone;
         this.customerUid = customerUid;
+    }
+
+    // Google OAuth 전용 생성자
+    public User(String name, String email, String phone, String customerUid, AuthProvider provider, String providerId) {
+        this.name = name;
+        this.email = email;
+        this.password = null;
+        this.phone = phone;
+        this.customerUid = customerUid;
+        this.provider = provider;
+        this.providerId = providerId;
     }
 
     // 사용자 정보 수정 - 이름, 전화번호 변경

--- a/src/main/java/sparta/paymentsystemserver/domain/user/service/UserService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import sparta.paymentsystemserver.domain.auth.dto.SignupResponse;
 import sparta.paymentsystemserver.domain.membership.entity.MembershipGradePolicy;
 import sparta.paymentsystemserver.domain.membership.entity.MembershipGradeType;
+import sparta.paymentsystemserver.domain.membership.exception.MembershipNotFoundException;
 import sparta.paymentsystemserver.domain.membership.service.MembershipService;
 import sparta.paymentsystemserver.domain.user.dto.UserRequest;
 import sparta.paymentsystemserver.domain.user.dto.UserResponse;
@@ -126,6 +127,6 @@ public class UserService {
         return membershipGradePolicyList.stream()
                 .filter(p -> p.getMembershipCode() == user.getMembershipGrade())
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.MEMBERSHIP_GRADE_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new MembershipNotFoundException(ErrorCode.MEMBERSHIP_GRADE_NOT_FOUND));
     }
 }

--- a/src/main/java/sparta/paymentsystemserver/global/config/SecurityConfig.java
+++ b/src/main/java/sparta/paymentsystemserver/global/config/SecurityConfig.java
@@ -12,6 +12,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import sparta.paymentsystemserver.domain.auth.handler.OAuth2SuccessHandler;
+import sparta.paymentsystemserver.domain.auth.service.CustomOAuth2UserService;
 import sparta.paymentsystemserver.global.jwt.JwtFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -26,6 +28,10 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -47,9 +53,17 @@ public class SecurityConfig {
                         "/api/auth/refresh",
                         "/api/webhooks/**",
                         "/api/public/**",
-                        "/actuator/health"
+                        "/actuator/health",
+                        "/login/oauth2/**",
+                        "/oauth2/**"
                 ).permitAll()
                 .anyRequest().authenticated()
+        );
+
+        http.oauth2Login(oauth2 -> oauth2
+                .userInfoEndpoint(userInfo -> userInfo
+                        .userService(customOAuth2UserService))
+                .successHandler(oAuth2SuccessHandler)
         );
 
         http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/sparta/paymentsystemserver/global/initializer/DataInitializer.java
+++ b/src/main/java/sparta/paymentsystemserver/global/initializer/DataInitializer.java
@@ -73,7 +73,8 @@ public class DataInitializer implements ApplicationRunner {
                         0L,
                         "NORMAL",
                         0L,
-                        "010-1111-1111"
+                        "010-1111-1111",
+                        "LOCAL"
                 },
                 new Object[]{
                         "admin1",
@@ -83,14 +84,15 @@ public class DataInitializer implements ApplicationRunner {
                         1000L,
                         "VIP",
                         300000L,
-                        "010-2222-2222"
+                        "010-2222-2222",
+                        "LOCAL"
                 }
         );
 
         jdbcTemplate.batchUpdate(
                 "INSERT INTO users " +
-                        "(name, email, password, customer_uid, point_balance, membership_grade, total_paid_amount, phone) " +
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                        "(name, email, password, customer_uid, point_balance, membership_grade, total_paid_amount, phone, provider) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 batchArgs
         );
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,17 @@ spring:
       - classpath:client-api-config.yml
   application:
     name: paymentSystemServer
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope:
+              - email
+              - profile
+
 
 portone:
   api:


### PR DESCRIPTION
**작업 설명**
 - 기존: 단순히 이메일과 비밀번호를 사용자로부터 입력받아서 회원가입을 처리함
 - 수정: 사용자 편의성을 높여주기 위해, OAuth2를 도입했다.

**수락 기준**
- 코드 컨벤션을 준수하였는가?
- 불필요한 코드가 존재하는가?

**추가 정보**
- AccessToken은 Google OAuth2의 리다이렉트를 구현하기 위한 URL에 포함