### PR TITLE
feat: 구독 플랜 및 도메인 구조 구현 및 웹훅, 동시성 보강

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    // 웹훅
+    implementation 'io.portone:server-sdk:0.23.0'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/controller/WebhookController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/controller/WebhookController.java
@@ -4,15 +4,16 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
-import sparta.paymentsystemserver.domain.payment.dto.PortOneWebhookRequest;
 import sparta.paymentsystemserver.domain.payment.dto.PortOneWebhookResponse;
 import sparta.paymentsystemserver.domain.payment.service.WebhookService;
 
-import java.util.Collections;
 
-// 포트원 웹훅 진입점 컨트롤러는
-// 1. 들어온 헤더와 핵심 payload 값을 로그로 남김
-// 2. 실제 비즈니스 처리는 WebhookService에 위임
+import static io.portone.sdk.server.webhook.WebhookVerifier.*;
+
+// 포트원 결제 웹훅의 진입점을 담당하는 컨트롤러
+// 1. 포트원으로부터 전달된 raw body와 웹훅 헤더를 수신한다
+// 2. Webhook-Id, Webhook-Signature, Webhook-Timestamp 헤더를 추출한다.
+// 3. 실제 서명 검증, payload 파싱, 비즈니스 처리는 WebhookService에 위임한다.
 @Slf4j
 @RestController
 @RequestMapping("/api/webhooks/payments")
@@ -21,29 +22,28 @@ public class WebhookController {
 
     private final WebhookService webhookService;
 
+    // 포트원 웹훅 요청을 수신한다
     @PostMapping
     public PortOneWebhookResponse receiveWebhook(
-            @RequestHeader(value = "Webhook-Id", required = false) String webhookId,
-            @RequestBody PortOneWebhookRequest request,
+            @RequestBody String rawBody,
             HttpServletRequest httpServletRequest
     ) {
-        Collections.list(httpServletRequest.getHeaderNames())
-                .forEach(name -> log.info("[Webhook][헤더] {}={}", name, httpServletRequest.getHeader(name)));
-
-        // 포트원은 Webhook-Id 헤더를 이벤트의 고유 식별자로 사용
-        String resolvedWebhookId = webhookId != null
-                ? webhookId
-                : httpServletRequest.getHeader("webhook-id");
-
-        log.info("[Webhook][매핑] webhookId={}", resolvedWebhookId);
         log.info(
-                "[Webhook][본문] type={}, paymentId={}, transactionId={}, storeId={}",
-                request.providerStatus(),
-                request.paymentId(),
-                request.data() != null ? request.data().transactionId() : null,
-                request.data() != null ? request.data().storeId() : null
-        );
+                "[Webhook][헤더] webhookId={}, webhookTimestamp={}",
+                httpServletRequest.getHeader(HEADER_ID),
+                httpServletRequest.getHeader(HEADER_TIMESTAMP));
 
-        return webhookService.processWebhook(resolvedWebhookId, request);
+        String webhookId = httpServletRequest.getHeader(HEADER_ID);
+        String webhookSignature = httpServletRequest.getHeader(HEADER_SIGNATURE);
+        String webhookTimestamp = httpServletRequest.getHeader(HEADER_TIMESTAMP);
+
+        log.info("[Webhook][매핑] webhookId={}", webhookId);
+
+        return webhookService.processWebhook(
+                webhookId,
+                rawBody,
+                webhookSignature,
+                webhookTimestamp
+        );
     }
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/entity/PaymentWebhookEvent.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/entity/PaymentWebhookEvent.java
@@ -20,11 +20,11 @@ public class PaymentWebhookEvent extends BaseEntity {
     private Long id;
 
     // 포트원이 보낸 웹훅 고유 Id 중복 수신 방지 키
-    @Column(nullable = false, unique = true, length = 60)
+    @Column(nullable = false, unique = true, length = 100)
     private String webhookId;
 
     // 이 이벤트가 가리키는 내부 페이먼트아이디
-    @Column(nullable = false, length = 40)
+    @Column(nullable = false, length = 80)
     private String paymentId;
 
     // 포트원 쪽에 상태 문자열 원본

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/repository/PaymentRepository.java
@@ -1,7 +1,11 @@
 package sparta.paymentsystemserver.domain.payment.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sparta.paymentsystemserver.domain.payment.entity.Payment;
 import sparta.paymentsystemserver.domain.payment.entity.PaymentStatus;
 
@@ -18,4 +22,9 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     // 주문에 연결된 READY 상태인 결제들을 조회
     List<Payment> findAllByOrder_IdAndStatus(Long orderId, PaymentStatus status);
+
+    // 결제 확정 시 동일 payment에 대한 동시 처리 충돌을 막기 위해 비관적 락으로 조회한다
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Payment p join fetch p.order join fetch p.user where p.paymentId = :paymentId")
+    Optional<Payment> findByPaymentIdForUpdate(@Param("paymentId") String paymentId);
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentService.java
@@ -102,7 +102,7 @@ public class PaymentService {
     // 클라이언트가 결제 성공이라고 보내더라도 서버가 포트원 결제 조회 API를 호출해 최종 상태를 검증한 뒤에만 결제를 확정
     @Transactional
     public PaymentResultResponse confirmPayment(String paymentId, Long userId) {
-        Payment payment = paymentRepository.findByPaymentId(paymentId)
+        Payment payment = paymentRepository.findByPaymentIdForUpdate(paymentId)
                 .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
 
         // 본인 결제만 확정할 수 있도록 소유권 검사
@@ -116,7 +116,7 @@ public class PaymentService {
     // 웹훅에서도 결제 확정 로직 재사용
     @Transactional
     public PaymentResultResponse confirmPaymentByWebhook(String paymentId) {
-        Payment payment = paymentRepository.findByPaymentId(paymentId)
+        Payment payment = paymentRepository.findByPaymentIdForUpdate(paymentId)
                 .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
 
         return confirmPaymentInternal(payment);

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookService.java
@@ -11,6 +11,7 @@ import sparta.paymentsystemserver.domain.payment.entity.PaymentStatus;
 import sparta.paymentsystemserver.domain.payment.entity.PaymentWebhookEvent;
 import sparta.paymentsystemserver.domain.payment.repository.PaymentRepository;
 import sparta.paymentsystemserver.domain.payment.repository.PaymentWebhookEventRepository;
+import tools.jackson.databind.ObjectMapper;
 
 // 포트원 웹훅 처리 서비스
 // 현재 웹훅 처리 정책
@@ -29,8 +30,32 @@ public class WebhookService {
     private final PaymentRepository paymentRepository;
     private final PaymentService paymentService;
     private final RefundService refundService;
+    private final ObjectMapper objectMapper;
+    private final WebhookSignatureService webhookSignatureService;
 
-    public PortOneWebhookResponse processWebhook(String webhookId, PortOneWebhookRequest request) {
+    // 웹훅 진입 메서드
+    // WebhookSignatureService를 통해 서명을 검증하고 -> raw body를 PortOneWebhookRequest로 파싱
+    // 파싱된 요청을 기존 이벤트 처리 메서드로 전잘
+    // 서명 검증 또는 페이로드 파싱에 실패하면 유효하지 않은 웹훅 요청으로 간주하고 실패 응답 반환
+    public PortOneWebhookResponse processWebhook(
+            String webhookId,
+            String rawBody,
+            String webhookSignature,
+            String webhookTimestamp
+    ) {
+        try {
+            webhookSignatureService.verify(rawBody, webhookId, webhookSignature, webhookTimestamp);
+
+            PortOneWebhookRequest request = objectMapper.readValue(rawBody, PortOneWebhookRequest.class);
+
+            return processWebhookEvent(webhookId, request);
+        } catch (Exception exception) {
+            log.error("[Webhook] 서명 검증 또는 payload 파싱 실패 - webhookId={}", webhookId, exception);
+            return new PortOneWebhookResponse(false, "유효하지 않은 webhook 요청입니다.");
+        }
+    }
+
+    public PortOneWebhookResponse processWebhookEvent(String webhookId, PortOneWebhookRequest request) {
         String paymentId = request.paymentId();
         String providerStatus = request.providerStatus();
         String resolvedWebhookId = resolveWebhookId(webhookId, paymentId);

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookSignatureService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookSignatureService.java
@@ -1,0 +1,43 @@
+package sparta.paymentsystemserver.domain.payment.service;
+
+import io.portone.sdk.server.errors.WebhookVerificationException;
+import io.portone.sdk.server.webhook.WebhookVerifier;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+// 포트원 웹훅 서명 검증을 담당하는 서비스
+// 설정값으로 주입된 webhook secret를 사용해서 WebhookVerifier를 초기화한다
+// raw body와 포트원 웹훅 헤더를 기준으로 서명을 검증함 검증 실패 시 예외를 발생시켜서 위조되거나 변조된 요청 처리를 막는다
+@Slf4j
+@Service
+public class WebhookSignatureService {
+
+    @Value("${portone.webhook.secret}")
+    private String webhookSecret;
+
+    private WebhookVerifier webhookVerifier;
+
+    // 주주입된 webhook secret으로 WebhookVerifier를 초기화함
+    @PostConstruct
+    void init() {
+        webhookVerifier = new WebhookVerifier(webhookSecret);
+    }
+
+    // 포트원 웹훅의 서명을 검증한다 raw body와 요청 헤더 기준으로 검증하고 검증 실패 시 예외를 발생시킨다
+    public void verify(String rawBody, String webhookId, String webhookSignature, String webhookTimestamp) {
+        try {
+            webhookVerifier.verify(
+                    rawBody,
+                    webhookId,
+                    webhookSignature,
+                    webhookTimestamp
+            );
+            log.info("[Webhook] 서명 검증 성공 - webhookId={}", webhookId);
+        } catch (WebhookVerificationException exception) {
+            log.error("[Webhook] 서명 검증 실패 - webhookId={}", webhookId, exception);
+            throw new IllegalArgumentException("유효하지 않은 webhook 서명입니다.", exception);
+        }
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/entity/BillingStatus.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/entity/BillingStatus.java
@@ -1,0 +1,11 @@
+package sparta.paymentsystemserver.domain.subscription.entity;
+
+// 구독 청구 이력의 상태
+public enum BillingStatus {
+    // 청구 생성 직후, 아직 결과 확정 전
+    PENDING,
+    // 결제 성공
+    COMPLETED,
+    // 결제 실패
+    FAILED
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/entity/PaymentMethod.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/entity/PaymentMethod.java
@@ -1,0 +1,103 @@
+package sparta.paymentsystemserver.domain.subscription.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sparta.paymentsystemserver.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+// 사용자의 빌링키를 저장하는 엔티티
+// 구독은 매번 사용자의 카드 정보 같은 것들을 다시 받지 않고 포트원에서 발급받은 빌링키를 사용해서 재결제를 수행한다
+// 어떤 사용자가 어떤 빌링키를 가지고 있는가 저장하는 역할
+@Getter
+@Entity
+@Table(name = "payment_methods")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentMethod {
+
+    // 결제 수단 PK
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 어떤 사용자의 결제수단인지 연결함. 한 사용자는 여러 결제수단을 가질 수 있으니까 ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 포트원에서 고객 식별용으로 사용하는 customerUid. 빌링키 발급하고 조회할 때 함께 사용될 수 있어서 저장
+    @Column(nullable = false, length = 100)
+    private String customerUid;
+
+    // 포트원에서 발급한 빌링키. 실제 정기결제랑 즉시청구 요청에 사용하는 값
+    @Column(nullable = false, length = 100)
+    private String billingKey;
+
+    // 결제 제공자를 구분하는데 지금은 포트원만 있긴 함
+    @Column(nullable = false, length = 50)
+    private String provider;
+
+    // 화면 표시용 카드사 이름 필수 값은 아님
+    @Column(length = 50)
+    private String cardCompany;
+
+    // 현재 사용 가능한 기본 결제수단인지 여부. 사용자가 카드 변경을 하면 기존 결제수단을 비활성화 한다
+    @Column(nullable = false)
+    private boolean active;
+
+    // 결제수단 등록 시각
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    private PaymentMethod(
+            User user,
+            String customerUid,
+            String billingKey,
+            String provider,
+            String cardCompany,
+            boolean active,
+            LocalDateTime createdAt
+    ) {
+        this.user = user;
+        this.customerUid = customerUid;
+        this.billingKey = billingKey;
+        this.provider = provider;
+        this.cardCompany = cardCompany;
+        this.active = active;
+        this.createdAt = createdAt;
+    }
+
+    // 새 빌링키를 발급 받아서 저장할 때 사용하는 메서드
+    public static PaymentMethod create(
+            User user,
+            String customerUid,
+            String billingKey,
+            String provider,
+            String cardCompany
+    ) {
+        return PaymentMethod.builder()
+                .user(user)
+                .customerUid(customerUid)
+                .billingKey(billingKey)
+                .provider(provider)
+                .cardCompany(cardCompany)
+                .active(true)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    // 더 이상 사용하지 않는 결제수단 비활성화. 실제 삭제 대신에 상태값만 변경해서 이력을 남긴다.
+    public void deactivate() {
+        this.active = false;
+    }
+
+    // 기존 결제수단을 다시 활성화. 동일 빌링키를 다시 사용하는 경우에는 새 엔티티를 만들지 않고 기존 엔티티를 재사용하기 위해서
+    public void activate() {
+        this.active = true;
+    }
+
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/entity/Subscription.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/entity/Subscription.java
@@ -1,0 +1,225 @@
+package sparta.paymentsystemserver.domain.subscription.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sparta.paymentsystemserver.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+// 실제 사용자의 구독 상태를 저장하는 구독 본체. 누가 어떤 플랜을 어떤 결제 수단으로 어떤 주기 상태로 구독하는지 기록
+@Getter
+@Entity
+@Table(name = "subscriptions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Subscription {
+
+    // 내부 디비 PK
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 외부 공개용 구독id
+    @Column(nullable = false, unique = false, length = 40)
+    private String subscriptionId;
+
+    // 구독한 사용자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 현재 적용 중인 플랜
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    // 다음 청구부터 적용할 예약 플랜. 변경 요청을 하면 다음 청구 성공 때 이 플랜으로 교체한다
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pending_plan_id")
+    private Plan pendingPlan;
+
+    // 결제에 사용할 빌링키(결제수단). 구독 생성하는 시점에 어떤 빌링키를 사용할지 연결한다
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_method_id", nullable = false)
+    private PaymentMethod paymentMethod;
+
+    // 현재 구독 상태
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SubscriptionStatus status;
+
+    // 생성 시점에 기준 실제 청구 금액. 이후에 플랜 가격이 바뀌더라도 당시 금액 이력을 분리해서 보려고 함
+    @Column(nullable = false)
+    private Long amount;
+
+    // 다음 청구부터 적용할 예약 금액
+    private Long pendingAmount;
+
+    // 현재 과금 구간 시작 시간. 예를 들어서 3월 구독 시작일.
+    @Column(nullable = false)
+    private LocalDateTime currentPeriodStart;
+
+    // 현재 과금 구간 종료 시각. 예를 들어서 3월 구독 종료일.
+    @Column(nullable = false)
+    private LocalDateTime currentPeriodEnd;
+
+    // 다음 청구 예정 시간. 스케줄러가 이 값을 기준으로 정기 결제를 수행한다
+    @Column(nullable = false)
+    private LocalDateTime nextBillingAt;
+
+    // 현재 결제 기간 유지하고 다음 결제부터 구독 종료할지 여부
+    @Column(nullable = false)
+    private boolean cancelAtPeriodEnd;
+
+    // 해지 시각. 해지하지 않았으면 null
+    private LocalDateTime cancelledAt;
+
+    // 구독 생성 시각
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+
+    @Builder
+    private Subscription(
+            String subscriptionId,
+            User user,
+            Plan plan,
+            Plan pendingPlan,
+            PaymentMethod paymentMethod,
+            SubscriptionStatus status,
+            Long amount,
+            Long pendingAmount,
+            LocalDateTime currentPeriodStart,
+            LocalDateTime currentPeriodEnd,
+            LocalDateTime nextBillingAt,
+            boolean cancelAtPeriodEnd,
+            LocalDateTime cancelledAt,
+            LocalDateTime createdAt
+    ) {
+        this.subscriptionId = subscriptionId;
+        this.user = user;
+        this.plan = plan;
+        this.pendingPlan = pendingPlan;
+        this.paymentMethod = paymentMethod;
+        this.status = status;
+        this.amount = amount;
+        this.pendingAmount = pendingAmount;
+        this.currentPeriodStart = currentPeriodStart;
+        this.currentPeriodEnd = currentPeriodEnd;
+        this.nextBillingAt = nextBillingAt;
+        this.cancelAtPeriodEnd = cancelAtPeriodEnd;
+        this.cancelledAt = cancelledAt;
+        this.createdAt = createdAt;
+    }
+
+    // 구독 생성은 과금이 아니라 구독 계약 정보만 만든다
+    public static Subscription create(
+            String subscriptionId,
+            User user,
+            Plan plan,
+            PaymentMethod paymentMethod
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return Subscription.builder()
+                .subscriptionId(subscriptionId)
+                .user(user)
+                .plan(plan)
+                .paymentMethod(paymentMethod)
+                .status(SubscriptionStatus.PENDING)
+                .amount(plan.getAmount())
+                .currentPeriodStart(now)
+                .currentPeriodEnd(now.plusMonths(1))
+                .nextBillingAt(now.plusMonths(1))
+                .cancelAtPeriodEnd(false)
+                .createdAt(now)
+                .build();
+    }
+
+    // 구독 해지 요청. ACTIVE 상태에서는 즉시 종료하지 않고 현재 결제 기간이 끝난 뒤에 해지되도록 예약
+    public void requestCancel() {
+        if (this.status == SubscriptionStatus.ACTIVE) {
+            this.cancelAtPeriodEnd = true;
+            return;
+        }
+
+        this.status = SubscriptionStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    // 예약 해지된 구독은 최종 종료 상태로 전환한다.
+    // 현재 결제 기간이 종료된 뒤에 스케줄러가 호출하는 메서드
+    public void completeCancellation() {
+        this.status = SubscriptionStatus.CANCELLED;
+        this.cancelAtPeriodEnd = false;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    // 미납
+    public void suspend() {
+        this.status = SubscriptionStatus.SUSPENDED;
+    }
+
+    // 기간 만료
+    public void expire() {
+        this.status = SubscriptionStatus.EXPIRED;
+    }
+
+    // 다음 청구부터 적용할 플랜/금액 변경 예약
+    public void reservePlanChange(Plan pendingPlan, Long pendingAmount) {
+        this.pendingPlan = pendingPlan;
+        this.pendingAmount = pendingAmount;
+    }
+
+    // 예약된 플랜/금액 변경을 실제 반영
+    public void applyPendingPlanChange() {
+        if (this.pendingPlan != null) {
+            this.plan = this.pendingPlan;
+            this.amount = this.pendingAmount;
+            this.pendingPlan = null;
+            this.pendingAmount = null;
+        }
+    }
+
+    // 첫 결제 성공 시에 첫 구독 주기를 시작하고 ACTIVE로 전환
+    public void activateFirstPeriod() {
+        LocalDateTime now = LocalDateTime.now();
+        applyPendingPlanChange();
+        this.currentPeriodStart = now;
+        this.currentPeriodEnd = now.plusMonths(1);
+        this.nextBillingAt = this.currentPeriodEnd;
+        this.status = SubscriptionStatus.ACTIVE;
+    }
+
+    // SUSPENDED 상태 재청구 성공 시에 현재 시점을 기준으로 구독 주기를 다시 시작한다
+    public void resumeBillingPeriod() {
+        LocalDateTime now = LocalDateTime.now();
+        applyPendingPlanChange();
+        this.currentPeriodStart = now;
+        this.currentPeriodEnd = now.plusMonths(1);
+        this.nextBillingAt = this.currentPeriodEnd;
+        this.status = SubscriptionStatus.ACTIVE;
+    }
+
+    // 한 번의 청구가 성공한 뒤에는 다음 이용 구간으로 갱신. 이때 예약된 플랜 변경이 있으면 함께 반영한다
+    public void renewNextPeriod() {
+        applyPendingPlanChange();
+        this.currentPeriodStart = this.currentPeriodEnd;
+        this.currentPeriodEnd = this.currentPeriodEnd.plusMonths(1);
+        this.nextBillingAt = this.currentPeriodEnd;
+        this.status = SubscriptionStatus.ACTIVE;
+    }
+
+    // 플랜 가격 정책 변경이 되면 현재 구독 금액을 다음 청구 기준으로 갱신
+    public void updateAmount(Long amount) {
+        this.amount = amount;
+    }
+
+    // 해지 예약을 취소하고 구독 계속 유지
+    public void resumeSubscription() {
+        this.cancelAtPeriodEnd = false;
+    }
+
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/entity/SubscriptionBilling.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/entity/SubscriptionBilling.java
@@ -1,0 +1,120 @@
+package sparta.paymentsystemserver.domain.subscription.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+// 구독 청구 이력을 저장하는 엔티티
+// 정기 결제는 한 번 성공했다고 끝이 아니고 이후 매달 반복 청구를 하니까 매번의 청구 시도를 별도 이력으로 남긴다
+// 같은 구독의 동일 청구 기간에 대해서는 billing 이력이 한 개만 생기게 유니크 제약을 둔다
+@Getter
+@Entity
+@Table(
+        name = "subscription_billings",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_subscription_billing_period",
+                        columnNames = {"subscription_id", "period_start", "period_end"}
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SubscriptionBilling {
+
+    // 청구 이력 PK
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 외부 공개용 청구 ID
+    @Column(nullable = false, unique = true, length = 40)
+    private String billingId;
+
+    // 어떤 구독에서 발생한 청구인지 연결한다
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subscription_id", nullable = false)
+    private Subscription subscription;
+
+    // 포트원이나 외부 결제 시스템의 결제 ID. 즉시청구 정기청구 성공할 때 저장
+    @Column(length = 100)
+    private String paymentId;
+
+    // 현재 청구 상태
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private BillingStatus status;
+
+    // 실제 청구 금액
+    @Column(nullable = false)
+    private Long amount;
+
+    // 이번 청구가 담당하는 구간 시작일
+    @Column(nullable = false)
+    private LocalDateTime periodStart;
+
+    // 이번 청구가 담당하는 구간 종료일
+    @Column(nullable = false)
+    private LocalDateTime periodEnd;
+
+    // 실제 청구 시도 시각
+    @Column(nullable = false)
+    private LocalDateTime attemptDate;
+
+    // 실패 사유. 성공할 때는 null
+    @Column(length = 300)
+    private String failureMessage;
+
+    @Builder
+    private SubscriptionBilling(
+            String billingId,
+            Subscription subscription,
+            String paymentId,
+            BillingStatus status,
+            Long amount,
+            LocalDateTime periodStart,
+            LocalDateTime periodEnd,
+            LocalDateTime attemptDate,
+            String failureMessage
+    ) {
+        this.billingId = billingId;
+        this.subscription = subscription;
+        this.paymentId = paymentId;
+        this.status = status;
+        this.amount = amount;
+        this.periodStart = periodStart;
+        this.periodEnd = periodEnd;
+        this.attemptDate = attemptDate;
+        this.failureMessage = failureMessage;
+    }
+
+    // 청구 시도를 시작할 때 만드는 초기 이력인데 이후 결제 성공이랑 실패에 따라서 상태를 갱신
+    public static SubscriptionBilling pending(String billingId, Subscription subscription) {
+        return SubscriptionBilling.builder()
+                .billingId(billingId)
+                .subscription(subscription)
+                .status(BillingStatus.PENDING)
+                .amount(subscription.getAmount())
+                .periodStart(subscription.getCurrentPeriodStart())
+                .periodEnd(subscription.getCurrentPeriodEnd())
+                .attemptDate(LocalDateTime.now())
+                .build();
+    }
+
+    // 청구 성공 처리
+    public void markCompleted(String paymentId) {
+        this.status = BillingStatus.COMPLETED;
+        this.paymentId = paymentId;
+        this.failureMessage = null;
+    }
+
+    // 청구 실패 처리
+    public void markFailed(String failureMessage) {
+        this.status = BillingStatus.FAILED;
+        this.failureMessage = failureMessage;
+    }
+
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/entity/SubscriptionStatus.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/entity/SubscriptionStatus.java
@@ -1,0 +1,16 @@
+package sparta.paymentsystemserver.domain.subscription.entity;
+
+// 구독의 현재 상태를 나타냄
+public enum SubscriptionStatus {
+
+    // 구독 생성은 됐지만 첫 청구가 아직 완료되지 않은 상태
+    PENDING,
+    // 현재 정상적으로 구독 중인 상태
+    ACTIVE,
+    // 사용자가 해지
+    CANCELLED,
+    // 미납, 연속 실패로 정지. 재구독 청구 가능
+    SUSPENDED,
+    // 기간 종료
+    EXPIRED
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/repository/PaymentMethodRepository.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/repository/PaymentMethodRepository.java
@@ -1,0 +1,21 @@
+package sparta.paymentsystemserver.domain.subscription.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sparta.paymentsystemserver.domain.subscription.entity.PaymentMethod;
+
+import java.util.List;
+import java.util.Optional;
+
+// 빌링키 조회용 레포지토리
+public interface PaymentMethodRepository extends JpaRepository<PaymentMethod, Long> {
+
+    // 포트원 연동 때 customerUid 기준으로 기존 빌링키가 있는지 확인할 때 사용
+    List<PaymentMethod> findAllByCustomerUid(String customerUid);
+
+    // 특정 사용자의 활성화되어 있는 결제수단을 조회한다
+    List<PaymentMethod> findAllByUserIdAndActiveTrue(Long userId);
+
+    // 사용자가 이미 등록한 빌링키인지 체크할 때 씀
+    Optional<PaymentMethod> findByUserIdAndBillingKey(Long userId, String billingKey);
+
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/repository/SubscriptionBillingRepository.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/repository/SubscriptionBillingRepository.java
@@ -1,0 +1,26 @@
+package sparta.paymentsystemserver.domain.subscription.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sparta.paymentsystemserver.domain.subscription.entity.Subscription;
+import sparta.paymentsystemserver.domain.subscription.entity.SubscriptionBilling;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+// 구독 청구 이력 조회용 레포지토리
+public interface SubscriptionBillingRepository extends JpaRepository<SubscriptionBilling, Long> {
+
+    // 특정 구독의 청구 이력을 최근 순으로 조회함 사용자가 내역 볼 때 사용
+    List<SubscriptionBilling> findAllBySubscriptionSubscriptionIdOrderByAttemptDateDesc(String subscriptionId);
+
+    // billingId로 단건 조회
+    Optional<SubscriptionBilling> findByBillingId(String billingId);
+
+    // 같은 구독과 같은 청구 기간에 빌링 이력이 이미 존재하는지 확인함
+    boolean existsBySubscriptionAndPeriodStartAndPeriodEnd(
+            Subscription subscription,
+            LocalDateTime periodStart,
+            LocalDateTime periodEnd
+    );
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/repository/SubscriptionRepository.java
@@ -1,0 +1,45 @@
+package sparta.paymentsystemserver.domain.subscription.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import sparta.paymentsystemserver.domain.subscription.entity.Subscription;
+import sparta.paymentsystemserver.domain.subscription.entity.SubscriptionStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+// 구독 조회하는 레포지토리
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+    // 특정 사용자의 현재 활성 구독 조회
+    Optional<Subscription> findByUserIdAndStatus(Long userId, SubscriptionStatus status);
+
+    // 자동 정기 청구 대상 구독을 조회함
+    // ACTIVE상태인지 nextBillingAt이랑 cancelAtPeriodEnd(해지 예약)이 걸려 있지 않은 구독
+    List<Subscription> findAllByStatusAndNextBillingAtBeforeAndCancelAtPeriodEndFalse(
+            SubscriptionStatus status,
+            LocalDateTime nextBillingAt
+    );
+
+    // 예약 해지된 구독 중에 현재 이용 기간이 끝난 구독을 조회함
+    List<Subscription> findAllByCancelAtPeriodEndTrueAndCurrentPeriodEndBefore(LocalDateTime currentPeriodEnd);
+
+    // 특정 사용자의 구독 1건 조회
+    Optional<Subscription> findBySubscriptionIdAndUserId(String subscriptionId, Long userId);
+
+    // 구독 상세 조회 할 때 plan이랑 paymentMethod를 함께 조회
+    @Query("""
+            select s
+            from Subscription s
+            join fetch s.plan p
+            join fetch s.paymentMethod pm
+            where s.subscriptionId = :subscriptionId
+            and s.user.id = :userId
+            """)
+    Optional<Subscription> findDetailBySubscriptionIdAndUserId(
+            @Param("subscriptionId") String subscriptionId,
+            @Param("userId") Long userId
+    );
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,8 @@ portone:
     kg-inicis: ${PORTONE_CHANNEL_KG}
     # billingKey 발급용 토스 페이먼츠 채널키
     toss: ${PORTONE_CHANNEL_TOSS}
+  webhook:
+    secret: ${PORTONE_WEBHOOK_SECRET}
 
 app:
   ui:


### PR DESCRIPTION
**작업 설명**
구독 기능의 기초가 되는 플랜/구독/청구 도메인 구조를 구현하고, 결제 영역의 동시성 및 웹훅 안정성을 함께 보강했습니다.
구독 도메인에서는 플랜, 구독 계약, 청구 이력 중심으로 엔티티와 레포지토리를 설계하고 상태 전이 정책을 반영했습니다. 결제 영역에서는 동일 결제에 대한 중복 확정 가능성을 줄이기 위해 비관적 락을 도입했고, 포트원 웹훅은 서명 검증과 이벤트 저장 흐름을 추가해 더 안전하게 처리하도록 정리했습니다.

**수락 기준**
- 사용자는 활성/진행 중 구독이 이미 있으면 중복 구독을 생성할 수 없다.
- 구독 생성 직후 상태는 PENDING이며, 첫 청구 성공 후 ACTIVE가 된다.
- 첫 청구 실패 시 구독은 PENDING을 유지하고 재시도할 수 있다.
- ACTIVE 상태 이후 정기 청구 실패 시 SUSPENDED가 된다.
- 해지 요청 시 즉시 종료되지 않고 cancelAtPeriodEnd=true로 예약 해지 처리된다.
- 같은 구독의 같은 청구 기간에 대해 billing 이력은 중복 생성되지 않는다.
- 동일 paymentId에 대한 결제 확정은 비관적 락으로 동시 처리 충돌을 방지한다.
- 포트원 웹훅 요청은 서명 검증을 통과한 경우에만 처리된다.
- 웹훅 이벤트는 payment_webhook_events에 저장되고, Paid/Cancelled 등 타입에 따라 분기 처리된다.

**추가 정보**
- 포트원 웹훅 시크릿은 설정값으로 주입받도록 구성
- 구독 도메인은 이후 스케줄러, 플랜 변경, 구독 관리 UI와 연결될 수 있도록 확장 가능한 구조로 설계했습니다.