### PR TITLE
feat: 구독 생성 조회 수정 api 구현

### DIFF
--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookService.java
@@ -3,7 +3,6 @@ package sparta.paymentsystemserver.domain.payment.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import sparta.paymentsystemserver.domain.payment.dto.PortOneWebhookRequest;
 import sparta.paymentsystemserver.domain.payment.dto.PortOneWebhookResponse;
 import sparta.paymentsystemserver.domain.payment.entity.Payment;

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookSignatureService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookSignatureService.java
@@ -6,6 +6,8 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import sparta.paymentsystemserver.domain.payment.exception.PaymentException;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
 
 // 포트원 웹훅 서명 검증을 담당하는 서비스
 // 설정값으로 주입된 webhook secret를 사용해서 WebhookVerifier를 초기화한다
@@ -19,7 +21,7 @@ public class WebhookSignatureService {
 
     private WebhookVerifier webhookVerifier;
 
-    // 주주입된 webhook secret으로 WebhookVerifier를 초기화함
+    // 주입된 webhook secret으로 WebhookVerifier를 초기화함
     @PostConstruct
     void init() {
         webhookVerifier = new WebhookVerifier(webhookSecret);
@@ -37,7 +39,7 @@ public class WebhookSignatureService {
             log.info("[Webhook] 서명 검증 성공 - webhookId={}", webhookId);
         } catch (WebhookVerificationException exception) {
             log.error("[Webhook] 서명 검증 실패 - webhookId={}", webhookId, exception);
-            throw new IllegalArgumentException("유효하지 않은 webhook 서명입니다.", exception);
+            throw new PaymentException(ErrorCode.INVALID_WEBHOOK_SIGNATURE);
         }
     }
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/controller/SubscriptionController.java
@@ -1,0 +1,48 @@
+package sparta.paymentsystemserver.domain.subscription.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import sparta.paymentsystemserver.domain.auth.dto.LoginUserData;
+import sparta.paymentsystemserver.domain.subscription.dto.CreateSubscriptionRequest;
+import sparta.paymentsystemserver.domain.subscription.dto.SubscriptionResponse;
+import sparta.paymentsystemserver.domain.subscription.dto.UpdateSubscriptionRequest;
+import sparta.paymentsystemserver.domain.subscription.service.SubscriptionService;
+
+// 구독 생성/조회/수정 api
+@RestController
+@RequestMapping("/api/subscriptions")
+@RequiredArgsConstructor
+public class SubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+
+    // 구독 생성 api 빌링키를 결제수단으로 등록하고 실제 과금은 없이 구독 계약 정보만 생성
+    @PostMapping
+    public SubscriptionResponse createSubscription(
+            @AuthenticationPrincipal LoginUserData loginUserData,
+            @Valid @RequestBody CreateSubscriptionRequest request
+    ) {
+        return subscriptionService.createSubscription(loginUserData.userId(), request);
+    }
+
+    // 내 구독 상세 조회 api
+    @GetMapping("/{subscriptionId}")
+    public SubscriptionResponse getSubscription(
+            @AuthenticationPrincipal LoginUserData loginUserData,
+            @PathVariable String subscriptionId
+    ) {
+        return subscriptionService.getSubscription(loginUserData.userId(), subscriptionId);
+    }
+
+    // 구독 상태 변경 api
+    @PatchMapping("/{subscriptionId}")
+    public SubscriptionResponse updateSubscription(
+            @AuthenticationPrincipal LoginUserData loginUserData,
+            @PathVariable String subscriptionId,
+            @Valid @RequestBody UpdateSubscriptionRequest request
+    ) {
+        return subscriptionService.updateSubscription(loginUserData.userId(), subscriptionId, request);
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/CreateSubscriptionRequest.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/CreateSubscriptionRequest.java
@@ -1,0 +1,24 @@
+package sparta.paymentsystemserver.domain.subscription.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+// 구독 생성 요청 dto
+// 프론트는 포트원SDK를 통해서 빌링키를 먼저 발급받고 그 결과를 이 요청으로 백엔드에 전달합니다
+// 이 요청은 실제 과금을 수행하는 것이 아니라 결제수단 등록이랑 구독 생성만 담당합니다
+public record CreateSubscriptionRequest(
+        @NotBlank(message = "customerUid는 필수입니다.")
+        String customerUid,
+
+        @NotBlank(message = "planId는 필수입니다.")
+        String planId,
+
+        @NotBlank(message = "billingKey는 필수입니다.")
+        String billingKey,
+
+        @NotNull(message = "amount는 필수입니다.")
+        @Positive(message = "amount는 0보다 커야 합니다.")
+        Long amount
+) {
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/SubscriptionResponse.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/SubscriptionResponse.java
@@ -1,0 +1,39 @@
+package sparta.paymentsystemserver.domain.subscription.dto;
+
+import sparta.paymentsystemserver.domain.subscription.entity.Subscription;
+
+import java.time.LocalDateTime;
+
+// 구독 생성/조회/수정 후 공통 응답 dto
+// 프론트 구독 관리 화면에서 필요한 값들을 한 번에 내려줌
+public record SubscriptionResponse(
+        String subscriptionId,
+        String customerUid,
+        String planId,
+        String pendingPlanId,
+        String paymentMethodId,
+        String status,
+        Boolean cancelAtPeriodEnd,
+        Long amount,
+        LocalDateTime currentPeriodStart,
+        LocalDateTime currentPeriodEnd,
+        LocalDateTime nextBillingAt
+) {
+
+    // Subscription 엔티티를 응답 dto로 변환
+    public static SubscriptionResponse from(Subscription subscription) {
+        return new SubscriptionResponse(
+                subscription.getSubscriptionId(),
+                subscription.getPaymentMethod().getCustomerUid(),
+                subscription.getPlan().getPlanId(),
+                subscription.getPendingPlan() != null ? subscription.getPendingPlan().getPlanId() : null,
+                String.valueOf(subscription.getPaymentMethod().getId()),
+                subscription.getStatus().name(),
+                subscription.isCancelAtPeriodEnd(),
+                subscription.getAmount(),
+                subscription.getCurrentPeriodStart(),
+                subscription.getCurrentPeriodEnd(),
+                subscription.getNextBillingAt()
+        );
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/UpdateSubscriptionRequest.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/UpdateSubscriptionRequest.java
@@ -1,0 +1,31 @@
+package sparta.paymentsystemserver.domain.subscription.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+// 구독 상태 변경 요청 dto
+public record UpdateSubscriptionRequest(
+        @NotBlank(message = "action은 필수입니다.")
+        String action,
+        String reason,
+        String planId
+) {
+    // 액션 문자열을 비교하기 쉽게 정규화함
+    public String normalizedAction() {
+        return action == null ? "" : action.trim().toLowerCase();
+    }
+
+    // 구독 해지 요청인지 확인함
+    public boolean isCancelAction() {
+        return "cancel".equals(normalizedAction());
+    }
+
+    // 플랜 변경 요청인지 확인함
+    public boolean isChangePlanAction() {
+        return "change_plan".equals(normalizedAction()) || "change-plan".equals(normalizedAction());
+    }
+
+    // 구독 재가입
+    public boolean isResumeAction() {
+        return "resume".equals(normalizedAction()) || "keep".equals(normalizedAction());
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/exception/SubscriptionException.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/exception/SubscriptionException.java
@@ -1,0 +1,16 @@
+package sparta.paymentsystemserver.domain.subscription.exception;
+
+import lombok.Getter;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
+
+// 구독 도메인 전용 예외 클래스
+@Getter
+public class SubscriptionException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public SubscriptionException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/service/SubscriptionService.java
@@ -1,0 +1,252 @@
+package sparta.paymentsystemserver.domain.subscription.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.paymentsystemserver.domain.subscription.dto.CreateSubscriptionRequest;
+import sparta.paymentsystemserver.domain.subscription.dto.SubscriptionResponse;
+import sparta.paymentsystemserver.domain.subscription.dto.UpdateSubscriptionRequest;
+import sparta.paymentsystemserver.domain.subscription.entity.PaymentMethod;
+import sparta.paymentsystemserver.domain.subscription.entity.Plan;
+import sparta.paymentsystemserver.domain.subscription.entity.Subscription;
+import sparta.paymentsystemserver.domain.subscription.entity.SubscriptionStatus;
+import sparta.paymentsystemserver.domain.subscription.exception.SubscriptionException;
+import sparta.paymentsystemserver.domain.subscription.repository.PaymentMethodRepository;
+import sparta.paymentsystemserver.domain.subscription.repository.PlanRepository;
+import sparta.paymentsystemserver.domain.subscription.repository.SubscriptionRepository;
+import sparta.paymentsystemserver.domain.user.entity.User;
+import sparta.paymentsystemserver.domain.user.repository.UserRepository;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
+import sparta.paymentsystemserver.global.util.PublicIdGenerator;
+
+import java.util.List;
+
+// 구독 생성/조회/상태 변경을 담당하는 서비스
+// 이 서비스는 실제 과금을 담당하지 않고 빌링키를 결제수단으로 저장. 구독 계약 정보만 생성하거나 조회하고 수정하는 역할만 맡는다
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscriptionService {
+
+    private final UserRepository userRepository;
+    private final PlanRepository planRepository;
+    private final PaymentMethodRepository paymentMethodRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final PublicIdGenerator publicIdGenerator;
+
+    // 구독 생성 처리 순서
+    // 1. 로그인 사용자 조회 하고 요청 customerUid가 현재 사용자 정보와 일치하는지 검증
+    // 2. 활성 플랜을 조회하고 요청 금액과 서버 플랜 금액이 일치하는지 검증
+    // 3. 빌링키를 현재 사용자의 활성 결제수단으로 등록하고 중복 여부를 검증한다
+    // 4. 실제 과금은 없이 구독 엔티티만 생성한다
+    @Transactional
+    public SubscriptionResponse createSubscription(Long userId, CreateSubscriptionRequest request) {
+        User user = getUser(userId);
+        validateCustomerUid(user, request.customerUid());
+
+        Plan plan = getActivePlan(request.planId());
+        validateRequestedAmount(plan, request.amount());
+
+        PaymentMethod paymentMethod = registerPaymentMethod(user, request);
+        validateDuplicatedSubscription(userId);
+
+        String subscriptionId = publicIdGenerator.generate("SUB");
+        Subscription subscription = Subscription.create(subscriptionId, user, plan, paymentMethod);
+        subscriptionRepository.save(subscription);
+
+        log.info("[Subscription] 구독 생성 완료 - userId={}, subscriptionId={}, planId={}",
+                userId,
+                subscription.getSubscriptionId(),
+                plan.getPlanId());
+
+        return SubscriptionResponse.from(subscription);
+    }
+
+    // 내 구독 1건을 조회함
+    public SubscriptionResponse getSubscription(Long userId, String subscriptionId) {
+        Subscription subscription = getSubscriptionDetail(userId, subscriptionId);
+        return SubscriptionResponse.from(subscription);
+    }
+
+    // 구독 상태를 변경함
+    @Transactional
+    public SubscriptionResponse updateSubscription(Long userId, String subscriptionId, UpdateSubscriptionRequest request) {
+        Subscription subscription = getSubscriptionDetail(userId, subscriptionId);
+
+        // 구독 해지
+        if (request.isCancelAction()) {
+            cancelSubscription(subscription);
+            return SubscriptionResponse.from(subscription);
+        }
+
+        // 다음 청구부터 적용할 플랜 변경을 예약함
+        if (request.isChangePlanAction()) {
+            changePlan(subscription, request.planId());
+            return SubscriptionResponse.from(subscription);
+        }
+
+        // 구독 해지 예약을 취소함
+        if (request.isResumeAction()) {
+            resumeSubscription(subscription);
+            return SubscriptionResponse.from(subscription);
+        }
+
+        throw new SubscriptionException(ErrorCode.SUBSCRIPTION_ACTION_INVALID);
+    }
+
+    // 현재 로그인 사용자 조회
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new SubscriptionException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    // 현재 판매 중인 플랜 조회
+    private Plan getActivePlan(String planId) {
+        Plan plan = planRepository.findByPlanId(planId)
+                .orElseThrow(() -> new SubscriptionException(ErrorCode.PLAN_NOT_FOUND));
+
+        if (!plan.isActive()) {
+            throw new SubscriptionException(ErrorCode.PLAN_NOT_ACTIVE);
+        }
+
+        return plan;
+    }
+
+    // 요청 customerUid가 로그인 사용자 소유인지 검증함
+    private void validateCustomerUid(User user, String customerUid) {
+        if (!user.getCustomerUid().equals(customerUid)) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_CUSTOMER_UID_MISMATCH);
+        }
+    }
+
+    // 프론트가 보낸 금액이랑 서버 플랜 금액이 일치하는지 검증
+    private void validateRequestedAmount(Plan plan, Long requestedAmount) {
+        if (!plan.getAmount().equals(requestedAmount)) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_AMOUNT_MISMATCH);
+        }
+    }
+
+    // 빌링키를 현재 사용자의 활성 결제수단으로 등록한다
+    // - 같은 사용자의 기존 활성 결제수단은 비활성화하고 동일 빌링키가 이미 저장되어 있으면 기존 엔티티 재활성화해서 재사용
+    // - 처음 보는 빌링키면 새 엔티티 생성
+    private PaymentMethod registerPaymentMethod(User user, CreateSubscriptionRequest request) {
+        List<PaymentMethod> activeMethods = paymentMethodRepository.findAllByUserIdAndActiveTrue(user.getId());
+        PaymentMethod existing = paymentMethodRepository.findByUserIdAndBillingKey(user.getId(), request.billingKey())
+                .orElse(null);
+
+        for (PaymentMethod method : activeMethods) {
+            if (existing == null || !method.getId().equals(existing.getId())) {
+                method.deactivate();
+            }
+        }
+
+        if (existing != null) {
+            existing.activate();
+            return existing;
+        }
+
+        PaymentMethod paymentMethod = PaymentMethod.create(
+                user,
+                request.customerUid(),
+                request.billingKey(),
+                "PORTONE",
+                null
+        );
+
+        return paymentMethodRepository.save(paymentMethod);
+    }
+
+    // 사용자의 중복 구독 여부 검증
+    // PENDING, ACTIVE, SUSPENDED 상태의 구독이 있으면 새 구독을 만들 수 없도록 막음
+    private void validateDuplicatedSubscription(Long userId) {
+        if (subscriptionRepository.findByUserIdAndStatus(userId, SubscriptionStatus.PENDING).isPresent()) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_ALREADY_ACTIVE);
+        }
+
+        if (subscriptionRepository.findByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE).isPresent()) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_ALREADY_ACTIVE);
+        }
+
+        if (subscriptionRepository.findByUserIdAndStatus(userId, SubscriptionStatus.SUSPENDED).isPresent()) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_SUSPENDED_EXISTS);
+        }
+    }
+
+    // 내 구독 상세를 조회한다
+    private Subscription getSubscriptionDetail(Long userId, String subscriptionId) {
+        return subscriptionRepository.findDetailBySubscriptionIdAndUserId(subscriptionId, userId)
+                .orElseThrow(() -> new SubscriptionException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+    }
+
+    // 구독 해지 요청을 처리함 현재 ACTIVE인 구독은 즉시 종료하지 않고
+    // 현재 이용기간이 끝난 뒤에 해지되도록 예약함
+    private void cancelSubscription(Subscription subscription) {
+        if (subscription.getStatus() == SubscriptionStatus.CANCELLED) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_ALREADY_CANCELLED);
+        }
+
+        if (subscription.getStatus() == SubscriptionStatus.EXPIRED) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_ALREADY_EXPIRED);
+        }
+
+        if (subscription.isCancelAtPeriodEnd()) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_ALREADY_CANCELLED);
+        }
+
+        subscription.requestCancel();
+
+        log.info("[Subscription] 구독 해지 요청 완료 - subscriptionId={}, cancelAtPeriodEnd={}",
+                subscription.getSubscriptionId(),
+                subscription.isCancelAtPeriodEnd());
+    }
+
+    // 플랜 변경 예약: 실제 플랜 변경은 즉시 안 하고 다음 청구 성공 시점에 반영되도록 예약만 함
+    private void changePlan(Subscription subscription, String planId) {
+        if (subscription.getStatus() == SubscriptionStatus.CANCELLED) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_ALREADY_CANCELLED);
+        }
+
+        if (subscription.getStatus() == SubscriptionStatus.EXPIRED) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_ALREADY_EXPIRED);
+        }
+
+        if (planId == null || planId.isBlank()) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_PLAN_ID_REQUIRED);
+        }
+
+        Plan targetPlan = getActivePlan(planId);
+
+        if (subscription.getPlan().getPlanId().equals(targetPlan.getPlanId())) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_CHANGE_NOT_ALLOWED);
+        }
+
+        subscription.reservePlanChange(targetPlan, targetPlan.getAmount());
+
+        log.info("[Subscription] 플랜 변경 예약 완료 - subscriptionId={}, currentPlanId={}, pendingPlanId={}",
+                subscription.getSubscriptionId(),
+                subscription.getPlan().getPlanId(),
+                targetPlan.getPlanId());
+    }
+
+    // 구독 해지 예약을 취소함
+    private void resumeSubscription(Subscription subscription) {
+        if (subscription.getStatus() == SubscriptionStatus.CANCELLED) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_ALREADY_CANCELLED);
+        }
+
+        if (subscription.getStatus() == SubscriptionStatus.EXPIRED) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_ALREADY_EXPIRED);
+        }
+
+        if (!subscription.isCancelAtPeriodEnd()) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_ACTION_INVALID);
+        }
+
+        subscription.resumeSubscription();
+
+        log.info("[Subscription] 구독 해지 예약 취소 완료 - subscriptionId={}",
+                subscription.getSubscriptionId());
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/global/exception/ErrorCode.java
+++ b/src/main/java/sparta/paymentsystemserver/global/exception/ErrorCode.java
@@ -43,6 +43,24 @@ public enum ErrorCode {
     REFUND_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "PAY007", "이미 환불 완료된 결제입니다."),
     REFUND_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "PAY008", "환불할 수 없는 결제 상태입니다."),
     REFUND_PROCESS_FAILED(HttpStatus.BAD_REQUEST, "PAY009", "PortOne 환불 처리에 실패했습니다."),
+    INVALID_WEBHOOK_SIGNATURE(HttpStatus.BAD_REQUEST, "PAY010", "유효하지 않은 webhook 서명입니다."),
+
+    //    구독 예외 (SUB###)
+    PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "SUB001", "플랜을 찾을 수 없습니다."),
+    PLAN_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "SUB002", "현재 판매 중인 플랜이 아닙니다."),
+    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SUB003", "구독 정보를 찾을 수 없습니다."),
+    SUBSCRIPTION_ALREADY_ACTIVE(HttpStatus.BAD_REQUEST, "SUB004", "이미 활성 구독이 존재합니다."),
+    SUBSCRIPTION_ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "SUB005", "이미 해지된 구독입니다."),
+    SUBSCRIPTION_ALREADY_EXPIRED(HttpStatus.BAD_REQUEST, "SUB006", "이미 만료된 구독입니다."),
+    SUBSCRIPTION_CHANGE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "SUB007", "현재와 동일한 플랜으로는 변경할 수 없습니다."),
+    SUBSCRIPTION_ACTION_INVALID(HttpStatus.BAD_REQUEST, "SUB008", "지원하지 않는 구독 액션입니다."),
+    SUBSCRIPTION_CUSTOMER_UID_MISMATCH(HttpStatus.BAD_REQUEST, "SUB009", "현재 사용자와 customerUid가 일치하지 않습니다."),
+    SUBSCRIPTION_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "SUB010", "플랜 금액과 요청 금액이 일치하지 않습니다."),
+    SUBSCRIPTION_PLAN_ID_REQUIRED(HttpStatus.BAD_REQUEST, "SUB011", "플랜 변경 시 planId는 필수입니다."),
+    SUBSCRIPTION_SUSPENDED_EXISTS(HttpStatus.BAD_REQUEST, "SUB012", "미납 정지 상태의 구독이 존재합니다."),
+    SUBSCRIPTION_BILLING_NOT_FOUND(HttpStatus.NOT_FOUND, "SUB013", "청구 이력을 찾을 수 없습니다."),
+    SUBSCRIPTION_BILLING_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "SUB014", "현재 상태에서는 청구를 실행할 수 없습니다."),
+
 
 //    포인트 예외 (PNT###)
     POINT_AMOUNT_INVALID(HttpStatus.BAD_REQUEST, "PNT001", "포인트 금액이 올바르지 않습니다."),

--- a/src/main/java/sparta/paymentsystemserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sparta/paymentsystemserver/global/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import sparta.paymentsystemserver.domain.order.exception.OrderException;
 import sparta.paymentsystemserver.domain.point.exception.PointException;
 import sparta.paymentsystemserver.domain.product.exception.ProductException;
 import sparta.paymentsystemserver.domain.payment.exception.PaymentException;
+import sparta.paymentsystemserver.domain.subscription.exception.SubscriptionException;
 import sparta.paymentsystemserver.domain.user.exception.UserException;
 
 import java.util.List;
@@ -86,6 +87,15 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(PaymentException.class)
     public ResponseEntity<ApiResponse<ErrorResponse>> handlePaymentException(PaymentException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+
+    //    구독 예외 로직 부분
+    @ExceptionHandler(SubscriptionException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleSubscriptionException(SubscriptionException e) {
         ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
                 .status(errorCode.getStatus())

--- a/src/main/resources/client-api-config.yml
+++ b/src/main/resources/client-api-config.yml
@@ -380,8 +380,8 @@ api:
               description: 결제 주기 (MONTHLY, QUARTERLY, ANNUAL)
 
     create-subscription:
-      url:
-      method:
+      url: /api/subscriptions
+      method: POST
       description: 구독 생성 (빌링키 저장 + 구독 생성을 하나의 트랜잭션으로 처리)
       request:
         fields:
@@ -411,11 +411,11 @@ api:
               usage: 구독 관리 페이지 리다이렉트에 사용
 
     get-subscription:
-      url:
-      method:
+      url:  /api/subscriptions/{subscriptionId}
+      method: GET
       description: 구독 조회
       pathParams:
-        - name:
+        - name: subscriptionId
           description: 구독 ID
       response:
         body:
@@ -430,6 +430,9 @@ api:
             - name: planId
               type: string
               required: true
+            - name: pendingPlanId
+              type: string
+              required: false
             - name: paymentMethodId
               type: string
               required: false
@@ -437,32 +440,45 @@ api:
             - name: status
               type: string
               required: true
-              description: "구독 상태 (ACTIVE: 활성, CANCELLED: 해지, SUSPENDED: 미납, EXPIRED: 기간 종료)"
+              description: "구독 상태 (PENDING: 첫 번째 청구 미납, ACTIVE: 활성, CANCELLED: 최종 종료 상태, SUSPENDED: ACTIVE 이후 정기 청구 실패 상태, EXPIRED: 기간 종료)"
             - name: amount
               type: number
+              required: true
+            - name: currentPeriodStart
+              type: string
               required: true
             - name: currentPeriodEnd
               type: string
               required: true
               description: "현재 이용 기간 종료일 (ISO 8601 형식, 예: 2026-03-01T23:59:59)"
+            - name: nextBillingAt
+              type: string
+              required: true
+            - name: cancelAtPeriodEnd
+              type: boolean
+              required: true
+              description: "true이면 해지 예약 상태이며 현재 기간 종료 후 구독이 종료됨"
 
     update-subscription:
-      url:
-      method:
+      url: /api/subscriptions/{subscriptionId}
+      method: PATCH
       description: 구독 상태 업데이트 (구독 해지)
       pathParams:
-        - name:
+        - name: subscriptionId
           description: 구독 ID
       request:
         fields:
           - name: action
             type: string
             required: true
-            description: "액션 타입: 'cancel' (구독 해지) 등"
+            description: "액션 값: 'cancel' (해지 예약), 'resume' 또는 'keep' (해지 예약 취소), 'changePlan' (플랜 변경 예약)"
           - name: reason
             type: string
             required: false
             description: 해지 사유
+          - name: planId
+            type: string
+            required: false
       response:
         body:
           fields:
@@ -479,11 +495,11 @@ api:
               description: 변경된 구독 상태
 
     create-billing:
-      url:
-      method:
+      url: /api/subscriptions/{subscriptionId}/billings
+      method: POST
       description: 즉시 결제 (현재 주기 청구 실행)
       pathParams:
-        - name:
+        - name: subscriptionId
           description: 구독 ID
       request:
         fields:
@@ -516,14 +532,14 @@ api:
             - name: status
               type: string
               required: true
-              description: "청구 상태 (COMPLETED: 결제 완료, FAILED: 실패)"
+              description: "청구 상태 (PENDING: 청구 생성 직후 대기 상태, COMPLETED: 결제 완료, FAILED: 결제 실패)"
 
     list-billing-history:
-      url:
-      method:
+      url: /api/subscriptions/{subscriptionId}/billings
+      method: GET
       description: 청구 내역 조회
       pathParams:
-        - name:
+        - name: subscriptionId
           description: 구독 ID
       response:
         body:
@@ -532,3 +548,4 @@ api:
               type: array
               required: true
               description: "청구 내역 배열. 각 요소는 { billingId: string (필수), periodStart: string (필수, ISO 8601), periodEnd: string (필수, ISO 8601), amount: number (필수), status: string (필수, COMPLETED/FAILED/PENDING), paymentId: string (선택), attemptDate: string (선택, ISO 8601), failureMessage: string (선택) } 형태"
+


### PR DESCRIPTION
**작업 설명**
구독 관리 기능 구현을 위해 구독 생성, 단건 조회, 상태 변경 API를 추가했습니다.
PortOne에서 발급한 billingKey를 결제수단으로 저장하고, 실제 과금 없이 구독 계약 정보만 생성하도록 구성했습니다.
구독은 생성 직후 PENDING 상태로 시작하며, 첫 결제가 성공해야 ACTIVE로 전환되도록 설계했습니다.

**수락 기준**
- POST /api/subscriptions 요청으로 billingKey 저장 및 구독 생성이 가능하다.
- 구독 생성 시 실제 과금은 발생하지 않는다.
- 생성된 구독은 DB PK가 아닌 SUB-... 형식의 공개 subscriptionId를 가진다.
- 구독 생성 직후 상태는 PENDING이다.
- GET /api/subscriptions/{subscriptionId} 요청으로 내 구독 상세 조회가 가능하다.
- 구독 상세 조회 시 plan, paymentMethod를 fetch join으로 함께 조회한다.
- PATCH /api/subscriptions/{subscriptionId} 요청으로 구독 해지 예약이 가능하다.
- 해지 요청 시 즉시 CANCELLED로 종료되지 않고 cancelAtPeriodEnd=true로 처리된다.
- PATCH /api/subscriptions/{subscriptionId} 요청으로 해지 예약 취소(resume 또는 keep)가 가능하다.
- PATCH /api/subscriptions/{subscriptionId} 요청으로 다음 청구부터 적용되는 플랜 변경 예약이 가능하다.
- 플랜 변경은 즉시 반영되지 않고 pendingPlan, pendingAmount에 예약된다.
- PENDING, ACTIVE, SUSPENDED 상태 구독이 있으면 중복 구독 생성이 차단된다.
- 해지 예약 상태의 구독은 내부적으로 ACTIVE + cancelAtPeriodEnd=true로 관리된다.
- CANCELLED, EXPIRED 상태 구독은 플랜 변경 예약이 차단된다.
- 첫 결제 실패 시 구독은 PENDING을 유지하며 재시도할 수 있다.
- ACTIVE 상태 이후 정기 청구 실패 시 SUSPENDED로 전환되는 정책을 따른다.
- client-api-config.yml에 구독 관련 엔드포인트 URL과 pathParams가 반영되어 프론트에서 정상 호출할 수 있다.

**추가 정보**
- create-subscription은 실제 과금이 아닌 billingKey 저장 + 구독 계약 생성 역할만 수행합니다.
- 실제 청구 실행과 청구 이력 조회는 별도 billing API 및 다음 작업 범위에서 구현합니다.
- 구독 금액은 Subscription.amount로 현재 적용 금액을 관리하고, 회차별 실제 청구 금액은 SubscriptionBilling.amount에 저장하는 정책으로 설계했습니다.
- 플랜 변경은 즉시 반영하지 않고 pendingPlan, pendingAmount로 예약한 뒤 다음 청구 성공 시 반영합니다.
- EXPIRED는 일반적인 해지 완료 상태가 아니라 무료 체험 만료나 자연 종료 같은 별도 정책이 있을 때 사용하는 예비 상태입니다.