### PR TITLE
refactor : product pessimisticLock add

### DIFF
--- a/src/main/java/sparta/paymentsystemserver/domain/product/repository/ProductRepository.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/product/repository/ProductRepository.java
@@ -1,6 +1,10 @@
 package sparta.paymentsystemserver.domain.product.repository;
 
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
 import sparta.paymentsystemserver.domain.product.entity.Product;
 import sparta.paymentsystemserver.domain.product.entity.ProductStatus;
 
@@ -14,6 +18,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     // 주문 목록 조회
     List<Product> findByStatusOrderByNameAsc(ProductStatus status);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "javax.persistence.lock.timeout", value = "3000"))
     List<Product> findAllByProductIdIn(List<String> productId);
 
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/product/service/ProductServiceImpl.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/product/service/ProductServiceImpl.java
@@ -19,13 +19,13 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ProductServiceImpl implements ProductService {
 
     private final ProductRepository productRepository;
     private final S3Service s3Service;
 
     // 상품 목록 조회
+    @Transactional(readOnly = true)
     public List<ProductResponse> getProducts() {
         return productRepository.findByStatusOrderByNameAsc(ProductStatus.ON_SALE)
                 .stream()
@@ -41,6 +41,7 @@ public class ProductServiceImpl implements ProductService {
     }
 
     // 상품 상세 조회(상품ID로 조회)
+    @Transactional(readOnly = true)
     public GetProductDetailResponse getProductDetail(String productId){
         Product product = productRepository.findByProductId(productId)
                 .orElseThrow(()-> new ProductException(ErrorCode.PRODUCT_NOT_FOUND));


### PR DESCRIPTION
**작업 설명**
- product pessimisticLock add

- remove getValidProductList transaction
  getValidProductList 에서 transaction read only를 사용하지만 부모 transaction 에서 터티체킹을 수행하고있음, 충돌 가능성이있으므로 제거