### PR TITLE
feat: 구독 청구 API 및 스케줄러 구현

### DIFF
--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/controller/BillingController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/controller/BillingController.java
@@ -1,0 +1,37 @@
+package sparta.paymentsystemserver.domain.subscription.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import sparta.paymentsystemserver.domain.auth.dto.LoginUserData;
+import sparta.paymentsystemserver.domain.subscription.dto.BillingHistoryResponse;
+import sparta.paymentsystemserver.domain.subscription.dto.BillingResponse;
+import sparta.paymentsystemserver.domain.subscription.dto.CreateBillingRequest;
+import sparta.paymentsystemserver.domain.subscription.service.BillingService;
+
+@RestController
+@RequestMapping("/api/subscriptions/{subscriptionId}/billings")
+@RequiredArgsConstructor
+public class BillingController {
+
+    private final BillingService billingService;
+
+    // 저장된 빌링키로 즉시 청구
+    @PostMapping
+    public BillingResponse createBilling(
+            @AuthenticationPrincipal LoginUserData loginUserData,
+            @PathVariable String subscriptionId,
+            @RequestBody CreateBillingRequest request
+    ) {
+        return billingService.createBilling(loginUserData.userId(), subscriptionId, request);
+    }
+
+    // 특정 구독의 청구 이력 조회
+    @GetMapping
+    public BillingHistoryResponse getBillingHistory(
+            @AuthenticationPrincipal LoginUserData loginUserData,
+            @PathVariable String subscriptionId
+    ) {
+        return billingService.getBillingHistory(loginUserData.userId(), subscriptionId);
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/BillingHistoryItemResponse.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/BillingHistoryItemResponse.java
@@ -1,0 +1,30 @@
+package sparta.paymentsystemserver.domain.subscription.dto;
+
+import sparta.paymentsystemserver.domain.subscription.entity.SubscriptionBilling;
+
+import java.time.LocalDateTime;
+
+// 청구 이력 단건 응답 dto
+public record BillingHistoryItemResponse(
+        String billingId,
+        LocalDateTime periodStart,
+        LocalDateTime periodEnd,
+        Long amount,
+        String status,
+        String paymentId,
+        LocalDateTime attemptDate,
+        String failureMessage
+) {
+    public static BillingHistoryItemResponse from(SubscriptionBilling billing) {
+        return new BillingHistoryItemResponse(
+                billing.getBillingId(),
+                billing.getPeriodStart(),
+                billing.getPeriodEnd(),
+                billing.getAmount(),
+                billing.getStatus().name(),
+                billing.getPaymentId(),
+                billing.getAttemptDate(),
+                billing.getFailureMessage()
+        );
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/BillingHistoryResponse.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/BillingHistoryResponse.java
@@ -1,0 +1,9 @@
+package sparta.paymentsystemserver.domain.subscription.dto;
+
+import java.util.List;
+
+// 청구 이력 목록 응답 dto
+public record BillingHistoryResponse(
+        List<BillingHistoryItemResponse> billings
+) {
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/BillingResponse.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/BillingResponse.java
@@ -1,0 +1,26 @@
+package sparta.paymentsystemserver.domain.subscription.dto;
+
+import sparta.paymentsystemserver.domain.subscription.entity.SubscriptionBilling;
+
+import java.time.LocalDateTime;
+
+// 청구 실행 결과 응답 dto
+public record BillingResponse(
+        String BillingId,
+        String paymentId,
+        Long amount,
+        String status,
+        LocalDateTime attemptDate,
+        String failureMessage
+) {
+    public static BillingResponse from(SubscriptionBilling billing) {
+        return new BillingResponse(
+                billing.getBillingId(),
+                billing.getPaymentId(),
+                billing.getAmount(),
+                billing.getStatus().name(),
+                billing.getAttemptDate(),
+                billing.getFailureMessage()
+        );
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/CreateBillingRequest.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/dto/CreateBillingRequest.java
@@ -1,0 +1,10 @@
+package sparta.paymentsystemserver.domain.subscription.dto;
+
+import java.time.LocalDateTime;
+
+// 즉시 청구 요청 dto
+public record CreateBillingRequest(
+        LocalDateTime periodStart,
+        LocalDateTime periodEnd
+) {
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/service/BillingService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/service/BillingService.java
@@ -1,0 +1,150 @@
+package sparta.paymentsystemserver.domain.subscription.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.paymentsystemserver.domain.subscription.dto.BillingHistoryItemResponse;
+import sparta.paymentsystemserver.domain.subscription.dto.BillingHistoryResponse;
+import sparta.paymentsystemserver.domain.subscription.dto.BillingResponse;
+import sparta.paymentsystemserver.domain.subscription.dto.CreateBillingRequest;
+import sparta.paymentsystemserver.domain.subscription.entity.Subscription;
+import sparta.paymentsystemserver.domain.subscription.entity.SubscriptionBilling;
+import sparta.paymentsystemserver.domain.subscription.entity.SubscriptionStatus;
+import sparta.paymentsystemserver.domain.subscription.exception.SubscriptionException;
+import sparta.paymentsystemserver.domain.subscription.repository.SubscriptionBillingRepository;
+import sparta.paymentsystemserver.domain.subscription.repository.SubscriptionRepository;
+import sparta.paymentsystemserver.global.client.PortOnePaymentClient;
+import sparta.paymentsystemserver.global.client.dto.PortOneBillingKeyPaymentInfo;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
+import sparta.paymentsystemserver.global.util.PublicIdGenerator;
+
+import java.util.List;
+
+
+// 구독 청구 실행과 청구 이력 조회 담당하는 서비스
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BillingService {
+
+    private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionBillingRepository subscriptionBillingRepository;
+    private final PortOnePaymentClient portOnePaymentClient;
+    private final PublicIdGenerator publicIdGenerator;
+
+    // 즉시 청구 실행
+    @Transactional
+    public BillingResponse createBilling(Long userId, String subscriptionId, CreateBillingRequest request) {
+        Subscription subscription = getSubscriptionDetail(userId, subscriptionId);
+        return processBilling(subscription);
+    }
+
+    // 스케줄러가 자동 청구할 때 사용하는 내부 청구 메서드
+    @Transactional
+    public BillingResponse createScheduledBilling(Subscription subscription) {
+        return processBilling(subscription);
+    }
+
+    // 실제 청구 실행 공통 로직
+    // 1. 현재 구독 상태에서 청구 가능한지 검증
+    // 2. 청구 이력을 PENDING 상태로 먼저 저장
+    // 3. 포트원 빌링키 결제 수행
+    // 4. 성공하면 청구 이력을 COMPLETED로 바꾸고 다음 기간으로 갱신
+    // 5. 실패하면 청구 이력을 FAILED로 바꿈 PENDING 상태 그대로 둔다
+    private BillingResponse processBilling(Subscription subscription) {
+        validateBillingAllowed(subscription);
+
+        if (subscriptionBillingRepository.existsBySubscriptionAndPeriodStartAndPeriodEnd(
+                subscription,
+                subscription.getCurrentPeriodStart(),
+                subscription.getCurrentPeriodEnd()
+        )) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_BILLING_NOT_ALLOWED);
+        }
+
+        String billingId = publicIdGenerator.generate("BIL");
+        String paymentId = publicIdGenerator.generate("PAY");
+
+        SubscriptionBilling billing = SubscriptionBilling.pending(billingId, subscription);
+        subscriptionBillingRepository.save(billing);
+
+        try {
+            PortOneBillingKeyPaymentInfo paymentInfo = portOnePaymentClient.payByBillingKey(
+                    paymentId,
+                    subscription.getPaymentMethod().getBillingKey(),
+                    subscription.getPlan().getName() + " 정기 결제",
+                    subscription.getUser().getCustomerUid(),
+                    subscription.getUser().getName(),
+                    subscription.getUser().getPhone(),
+                    subscription.getUser().getEmail(),
+                    subscription.getAmount()
+            );
+
+            billing.markCompleted(paymentInfo.paymentId());
+
+            if (subscription.getStatus() == SubscriptionStatus.PENDING) {
+                subscription.activateFirstPeriod();
+            } else if (subscription.getStatus() == SubscriptionStatus.SUSPENDED) {
+                subscription.resumeBillingPeriod();
+            } else {
+                subscription.renewNextPeriod();
+            }
+
+            log.info("[Billing] 청구 성공 - subscriptionId={}, billingId={}, paymentId={}",
+                    subscription.getSubscriptionId(),
+                    billing.getBillingId(),
+                    paymentInfo.paymentId());
+
+            return BillingResponse.from(billing);
+        } catch (Exception exception) {
+            String failureMessage = exception.getMessage() != null
+                    ? exception.getMessage()
+                    : "청구 처리 중 알 수 없는 오류가 발생했습니다.";
+
+            billing.markFailed(failureMessage);
+
+            if (subscription.getStatus() == SubscriptionStatus.ACTIVE) {
+                subscription.suspend();
+            }
+
+            log.error("[Billing] 청구 실패 - subscriptionId={}, billingId={}, failureMessage={}",
+                    subscription.getSubscriptionId(),
+                    billing.getBillingId(),
+                    failureMessage);
+
+            return BillingResponse.from(billing);
+        }
+    }
+
+    // 특정 구독 청구 이력 조회
+    public BillingHistoryResponse getBillingHistory(Long userId, String subscriptionId) {
+        Subscription subscription = getSubscriptionDetail(userId, subscriptionId);
+
+        List<BillingHistoryItemResponse> billings = subscriptionBillingRepository
+                .findAllBySubscriptionSubscriptionIdOrderByAttemptDateDesc(subscription.getSubscriptionId())
+                .stream()
+                .map(BillingHistoryItemResponse::from)
+                .toList();
+
+        return new BillingHistoryResponse(billings);
+    }
+
+    // 현재 로그인 사용자의 구독 조회
+    private Subscription getSubscriptionDetail(Long userId, String subscriptionId) {
+        return subscriptionRepository.findDetailBySubscriptionIdAndUserId(subscriptionId, userId)
+                .orElseThrow(() -> new SubscriptionException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+    }
+
+    // 현재 상태에서 청구가 가능한지 검증
+    // 해지 예약된 구독(cancelAtPeriodEnd=true)는 현재 기간 유지하더라도 다음 청구 수행하면 안 되니까 billing 대상에서 제외
+    private void validateBillingAllowed(Subscription subscription) {
+        if (subscription.getStatus() == SubscriptionStatus.CANCELLED
+                || subscription.getStatus() == SubscriptionStatus.EXPIRED
+                || subscription.isCancelAtPeriodEnd()) {
+            throw new SubscriptionException(ErrorCode.SUBSCRIPTION_BILLING_NOT_ALLOWED);
+        }
+    }
+}
+

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/service/SubscriptionScheduler.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/service/SubscriptionScheduler.java
@@ -1,0 +1,90 @@
+package sparta.paymentsystemserver.domain.subscription.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.paymentsystemserver.domain.subscription.dto.BillingResponse;
+import sparta.paymentsystemserver.domain.subscription.entity.Subscription;
+import sparta.paymentsystemserver.domain.subscription.entity.SubscriptionStatus;
+import sparta.paymentsystemserver.domain.subscription.repository.SubscriptionRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// 구독 자동 정기 청구와 예약 해지 완료 처리를 담당하는 스케줄러
+// ACTIVE 상태면서 nextBillingAt이 지난 구독을 찾아서 자동 청구함
+// 실행 주기는 매시간마다 1회 실행
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubscriptionScheduler {
+
+    private final SubscriptionRepository subscriptionRepository;
+    private final BillingService billingService;
+
+    // 구독 스케줄러 메인 실행 메서드 매시간 0분 0초에 실행함
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional
+    public void runSubscriptionScheduler() {
+        log.info("[구독 스케줄러] 실행 시작");
+
+        LocalDateTime now = LocalDateTime.now();
+
+        processScheduledBillings(now);
+        processScheduledCancellations(now);
+
+        log.info("[구독 스케줄러] 실행 완료");
+    }
+
+    // 자동 청구 대상 구독을 조회해서 청구를 실행함
+    protected void processScheduledBillings(LocalDateTime now) {
+        List<Subscription> targets = subscriptionRepository
+                .findAllByStatusAndNextBillingAtBeforeAndCancelAtPeriodEndFalse(
+                        SubscriptionStatus.ACTIVE,
+                        now
+                );
+
+        if (targets.isEmpty()) {
+            log.info("[구독 스케줄러] 자동 청구 대상 없음");
+            return;
+        }
+
+        log.info("[구독 스케줄러] 자동 청구 대상 {}건 처리 시작", targets.size());
+
+        for (Subscription subscription : targets) {
+            try {
+                BillingResponse result = billingService.createScheduledBilling(subscription);
+
+                log.info("[구독 스케줄러] 자동 청구 처리 완료 - subscriptionId={}, billingStatus={}",
+                        subscription.getSubscriptionId(),
+                        result.status());
+            } catch (Exception exception) {
+                log.error("[구독 스케줄러] 자동 청구 처리 실패 - subscriptionId={}, error={}",
+                        subscription.getSubscriptionId(),
+                        exception.getMessage());
+            }
+        }
+    }
+
+    // 예약 해지된 구독 중에 현재 이용 기간이 끝난 구독을 최종 종료 처리함
+    protected void processScheduledCancellations(LocalDateTime now) {
+        List<Subscription> targets = subscriptionRepository
+                .findAllByCancelAtPeriodEndTrueAndCurrentPeriodEndBefore(now);
+
+        if (targets.isEmpty()) {
+            log.info("[구독 스케줄러] 해지 완료 대상 없음");
+            return;
+        }
+
+        log.info("[구독 스케줄러] 해지 완료 대상 {}건 처리 시작", targets.size());
+
+        for (Subscription subscription : targets) {
+            subscription.completeCancellation();
+
+            log.info("[구독 스케줄러] 해지 완료 처리 - subscriptionId={}",
+                    subscription.getSubscriptionId());
+        }
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/global/client/PortOnePaymentClient.java
+++ b/src/main/java/sparta/paymentsystemserver/global/client/PortOnePaymentClient.java
@@ -1,5 +1,6 @@
 package sparta.paymentsystemserver.global.client;
 
+import sparta.paymentsystemserver.global.client.dto.PortOneBillingKeyPaymentInfo;
 import sparta.paymentsystemserver.global.client.dto.PortOneCancelInfo;
 import sparta.paymentsystemserver.global.client.dto.PortOnePaymentInfo;
 
@@ -11,4 +12,16 @@ public interface PortOnePaymentClient {
 
     // paymentId 기준으로 포트원 전액 환불 요청
     PortOneCancelInfo cancelPayment(String paymentId, String reason);
+
+    // 저장된 빌링키로 단건 결제 수행
+    PortOneBillingKeyPaymentInfo payByBillingKey(
+            String paymentId,
+            String billingKey,
+            String orderName,
+            String customerId,
+            String fullName,
+            String phoneNumber,
+            String email,
+            Long amount
+    );
 }

--- a/src/main/java/sparta/paymentsystemserver/global/client/PortOnePaymentClientImpl.java
+++ b/src/main/java/sparta/paymentsystemserver/global/client/PortOnePaymentClientImpl.java
@@ -1,12 +1,16 @@
 package sparta.paymentsystemserver.global.client;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 import sparta.paymentsystemserver.domain.payment.exception.PaymentException;
+import sparta.paymentsystemserver.global.client.dto.PortOneBillingKeyPaymentInfo;
+import sparta.paymentsystemserver.global.client.dto.PortOneBillingKeyPaymentRequest;
+import sparta.paymentsystemserver.global.client.dto.PortOneBillingKeyPaymentResponse;
 import sparta.paymentsystemserver.global.client.dto.PortOneCancelInfo;
 import sparta.paymentsystemserver.global.client.dto.PortOneCancelRequest;
 import sparta.paymentsystemserver.global.client.dto.PortOneCancelResponse;
@@ -15,6 +19,9 @@ import sparta.paymentsystemserver.global.client.dto.PortOnePaymentResponse;
 import sparta.paymentsystemserver.global.config.properties.PortOneProperties;
 import sparta.paymentsystemserver.global.exception.ErrorCode;
 
+// 포트원 REST API와 통신하는 결제 클라이언트 구현체
+// 결제 단건 조회, 결제 취소, 빌링키 기반 단건 청구 요청 담당
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PortOnePaymentClientImpl implements PortOnePaymentClient {
@@ -22,7 +29,8 @@ public class PortOnePaymentClientImpl implements PortOnePaymentClient {
     private final RestClient.Builder restClientBuilder;
     private final PortOneProperties portOneProperties;
 
-    // paymentId 기준으로 포트원 결제 재조회
+    // 포트원 결제 단건 조회 api를 호출해서 외부 결제 상태를 조회함
+    // 결제 검증 단계에서 실제 포트원 결제 정보랑 내부 결제 정보를 비교하기 위해 사용
     @Override
     public PortOnePaymentInfo getPayment(String paymentId) {
         try {
@@ -45,7 +53,8 @@ public class PortOnePaymentClientImpl implements PortOnePaymentClient {
         }
     }
 
-    // paymentId 기준으로 포트원 전액 환불 요청
+    // 포트원 결제 취소 api를 호출해서 이미 결제된 건을 환불, 취소 처리함
+    // 내부 환불 요청 시에 포트원 취소가 실제로 완료되었는지 확인하기 위한 응답 정보로 변환
     @Override
     public PortOneCancelInfo cancelPayment(String paymentId, String reason) {
         try {
@@ -68,7 +77,85 @@ public class PortOnePaymentClientImpl implements PortOnePaymentClient {
         }
     }
 
-    // 포트원 호출에 공통으로 사용할 RestClient 생성
+    // 저장된 빌링키로 포트원 빌링키 단건 결제를 요청함
+    // 요청 시 빌링키와 함께 storeId, channelKey, 고객 정보, 금액을 전달하고 응답의 pgTxId와 paidAt 값을 기준으로 실제 청구 성공여부 판단
+    @Override
+    public PortOneBillingKeyPaymentInfo payByBillingKey(
+            String paymentId,
+            String billingKey,
+            String orderName,
+            String customerId,
+            String fullName,
+            String phoneNumber,
+            String email,
+            Long amount
+    ) {
+        try {
+            String storeId = portOneProperties.getStore().getId();
+            String channelKey = portOneProperties.getChannel() == null
+                    ? null
+                    : portOneProperties.getChannel().get("toss");
+
+            // 포트원 빌링키 결제 스펙에 맞는 요청 본문을 생성함
+            PortOneBillingKeyPaymentRequest request = PortOneBillingKeyPaymentRequest.of(
+                    billingKey,
+                    orderName,
+                    customerId,
+                    fullName,
+                    phoneNumber,
+                    email,
+                    amount,
+                    storeId,
+                    channelKey
+            );
+
+            log.info("[Billing] 포트원 빌링키 결제 요청 - storeId={}, channelKey={}, paymentId={}, customerId={}, amount={}",
+                    storeId,
+                    channelKey,
+                    paymentId,
+                    customerId,
+                    amount);
+
+            PortOneBillingKeyPaymentResponse response = buildRestClient()
+                    .post()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/payments/{paymentId}/billing-key")
+                            .build(paymentId))
+                    .body(request)
+                    .retrieve()
+                    .body(PortOneBillingKeyPaymentResponse.class);
+
+            if (response == null) {
+                throw new PaymentException(ErrorCode.PAYMENT_VERIFICATION_FAILED);
+            }
+
+            // providerPaymentId(pgTxId)와 상태값이 모두 있어야 실제 청구 성공으로 봄
+            PortOneBillingKeyPaymentInfo paymentInfo = response.toInfo(paymentId);
+
+            log.info("[Billing] 포트원 빌링키 결제 응답 - paymentId={}, providerPaymentId={}, status={}",
+                    paymentInfo.paymentId(),
+                    paymentInfo.providerPaymentId(),
+                    paymentInfo.status());
+
+            if (paymentInfo.providerPaymentId() == null || paymentInfo.providerPaymentId().isBlank()
+                    || paymentInfo.status() == null || paymentInfo.status().isBlank()) {
+                throw new PaymentException(ErrorCode.PAYMENT_VERIFICATION_FAILED);
+            }
+
+            return paymentInfo;
+        } catch (RestClientResponseException exception) {
+            log.error("[Billing] 포트원 빌링키 결제 호출 실패 - statusCode={}, responseBody={}",
+                    exception.getStatusCode(),
+                    exception.getResponseBodyAsString());
+
+            throw new PaymentException(ErrorCode.PAYMENT_VERIFICATION_FAILED);
+        } catch (Exception exception) {
+            throw new PaymentException(ErrorCode.PAYMENT_VERIFICATION_FAILED);
+        }
+    }
+
+    // 포트원 api 호출에 공통으로 사용할 RestClient를 생성함
+    // baseUrl, 인증 헤더랑 json content-type을 공통 설정으로 적용함
     private RestClient buildRestClient() {
         return restClientBuilder
                 .baseUrl(portOneProperties.getApi().getBaseUrl())

--- a/src/main/java/sparta/paymentsystemserver/global/client/dto/PortOneBillingKeyPaymentInfo.java
+++ b/src/main/java/sparta/paymentsystemserver/global/client/dto/PortOneBillingKeyPaymentInfo.java
@@ -1,0 +1,9 @@
+package sparta.paymentsystemserver.global.client.dto;
+
+// 빌링키 결제 결과를 서비스에서 다루기 위한 내부 dto
+public record PortOneBillingKeyPaymentInfo(
+        String paymentId,
+        String status,
+        String providerPaymentId
+) {
+}

--- a/src/main/java/sparta/paymentsystemserver/global/client/dto/PortOneBillingKeyPaymentRequest.java
+++ b/src/main/java/sparta/paymentsystemserver/global/client/dto/PortOneBillingKeyPaymentRequest.java
@@ -1,0 +1,50 @@
+package sparta.paymentsystemserver.global.client.dto;
+
+// 포트원 빌링키 단건 결제 요청 dto
+public record PortOneBillingKeyPaymentRequest(
+        String billingKey,
+        String orderName,
+        Customer customer,
+        Amount amount,
+        String storeId,
+        String channelKey,
+        String currency
+) {
+    // 내부 결제 정보로부터 포트원 빌링키 결제 요청 dto를 생성
+    public static PortOneBillingKeyPaymentRequest of(
+            String billingKey,
+            String orderName,
+            String customerId,
+            String fullName,
+            String phoneNumber,
+            String email,
+            Long amount,
+            String storeId,
+            String channelKey
+    ) {
+        return new PortOneBillingKeyPaymentRequest(
+                billingKey,
+                orderName,
+                new Customer(customerId, fullName, phoneNumber, email),
+                new Amount(amount),
+                storeId,
+                channelKey,
+                "KRW"
+        );
+    }
+
+    // 포트원 결제 요청에 포함되는 고객 정보 객체
+    public record Customer(
+            String id,
+            String fullName,
+            String phoneNumber,
+            String email
+    ) {
+    }
+
+    // 포트원 결제 요청에 포함되는 결제 금액 객체
+    public record Amount(
+            Long total
+    ) {
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/global/client/dto/PortOneBillingKeyPaymentResponse.java
+++ b/src/main/java/sparta/paymentsystemserver/global/client/dto/PortOneBillingKeyPaymentResponse.java
@@ -1,0 +1,36 @@
+package sparta.paymentsystemserver.global.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+// 포트원 빌링키 단건 결제 응답 dto
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PortOneBillingKeyPaymentResponse(
+        Payment payment
+) {
+
+    // 포트원 빌링키 결제 응답의 중첩 payment 객체. 결제 완료 여부와 PG 거래 식별자를 담음
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Payment(
+            String pgTxId,
+            String paidAt
+    ) {
+    }
+
+    // 포트원 빌링키 결제 응답에서 필요한 값만 추려서 내부 결제 정보 객체로 변환
+    public PortOneBillingKeyPaymentInfo toInfo(String paymentId) {
+        if (payment == null) {
+            return new PortOneBillingKeyPaymentInfo(paymentId, null, null);
+        }
+
+        String status = payment.paidAt() != null && !payment.paidAt().isBlank()
+                ? "PAID"
+                : null;
+
+        return new PortOneBillingKeyPaymentInfo(
+                paymentId,
+                status,
+                payment.pgTxId()
+        );
+    }
+}
+


### PR DESCRIPTION
**작업 설명**
구독 청구 기능 구현을 위해 수동 billing 실행 API와 청구 이력 조회 API를 추가했습니다.
저장된 billingKey를 이용해 PortOne billing-key 결제를 수행하고, 청구 결과를 SubscriptionBilling 이력으로 누적 저장하도록 구성했습니다. 또한 자동 정기 청구와 예약 해지 완료 처리를 위해 구독 스케줄러를 추가했습니다. 중복 billing 방지를 위해 동일 구독의 동일 청구 기간에 대해서는 billing 이력이 한 번만 생성되도록 서비스 레벨 검증과 DB 유니크 제약을 함께 적용했습니다.

**수락 기준**
- POST /api/subscriptions/{subscriptionId}/billings 요청으로 구독 청구를 실행할 수 있다.
- 저장된 billingKey를 이용해 PortOne billing-key 결제를 수행한다.
- 청구 성공 시 SubscriptionBilling 이력이 COMPLETED 상태로 저장된다.
- 첫 청구 성공 시 구독 상태는 PENDING -> ACTIVE로 전환된다.
- SUSPENDED 상태에서 재청구 성공 시 구독 상태는 ACTIVE로 복구된다.
- SUSPENDED 상태에서 재청구 성공하면 현재 시점을 기준으로 currentPeriodStart, currentPeriodEnd, nextBillingAt이 다시 설정된다.
- 첫 청구 실패 시 구독은 PENDING을 유지한다.
- ACTIVE 상태 이후 정기 청구 실패 시 구독은 SUSPENDED로 전환된다.
- GET /api/subscriptions/{subscriptionId}/billings 요청으로 청구 이력을 최신순으로 조회할 수 있다.
- 동일 구독의 동일 청구 기간(subscription_id, period_start, period_end)에 대해 billing 이력은 중복 생성되지 않는다.
- 구독 스케줄러는 ACTIVE && cancelAtPeriodEnd=false && nextBillingAt <= now 조건의 구독만 자동 청구 대상으로 처리한다.
- 해지 예약 상태(cancelAtPeriodEnd=true)의 구독은 자동 정기 청구 대상에서 제외된다.
- 현재 이용 기간이 끝난 해지 예약 구독은 스케줄러에 의해 최종 CANCELLED 처리된다.

**추가 정보**
- 자동 정기 청구 스케줄러는 매시간 1회 실행되며, nextBillingAt <= now 조건으로 대상을 판별합니다.
- 해지 예약은 별도 상태 enum이 아니라 ACTIVE + cancelAtPeriodEnd=true 조합으로 표현합니다.