### PR TITLE
refactor: 결제/환불 트랜잭션 경계 정리 및 refund 도메인 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,11 @@ dependencies {
     // 웹훅
     implementation 'io.portone:server-sdk:0.23.0'
 
+    // ShedLock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.16.0'
+
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/controller/PaymentController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/controller/PaymentController.java
@@ -5,12 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import sparta.paymentsystemserver.domain.auth.dto.LoginUserData;
-import sparta.paymentsystemserver.domain.payment.dto.CancelPaymentRequest;
 import sparta.paymentsystemserver.domain.payment.dto.CreatePaymentRequest;
 import sparta.paymentsystemserver.domain.payment.dto.CreatePaymentResponse;
 import sparta.paymentsystemserver.domain.payment.dto.PaymentResultResponse;
 import sparta.paymentsystemserver.domain.payment.service.PaymentService;
-import sparta.paymentsystemserver.domain.payment.service.RefundService;
 
 // 결제를 생성하고 확정, 환불을 하는 API입니다
 @RestController
@@ -19,7 +17,6 @@ import sparta.paymentsystemserver.domain.payment.service.RefundService;
 public class PaymentController {
 
     private final PaymentService paymentService;
-    private final RefundService refundService;
 
     // 결제 시도 생성 API JWT에서 꺼낸 현재 로그인 사용자 정보 사용
     @PostMapping
@@ -37,16 +34,6 @@ public class PaymentController {
             @AuthenticationPrincipal LoginUserData loginUserData
     ) {
         return paymentService.confirmPayment(paymentId, loginUserData.userId());
-    }
-
-    // 전액 환불 요청 API, 클라이언트는 환불 요청만 보내고 실제 포트원 결제 취소와 내부 환불 상태 반영은 서버가 책임진다
-    @PostMapping("/{paymentId}/cancel")
-    public PaymentResultResponse cancelPayment(
-            @PathVariable String paymentId,
-            @AuthenticationPrincipal LoginUserData loginUserData,
-            @RequestBody CancelPaymentRequest request
-    ) {
-        return refundService.cancelPayment(paymentId, loginUserData.userId(), request.reason());
     }
 
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/controller/WebhookController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/controller/WebhookController.java
@@ -3,15 +3,19 @@ package sparta.paymentsystemserver.domain.payment.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import sparta.paymentsystemserver.domain.payment.dto.PortOneWebhookResponse;
 import sparta.paymentsystemserver.domain.payment.service.WebhookService;
 
+import static io.portone.sdk.server.webhook.WebhookVerifier.HEADER_ID;
+import static io.portone.sdk.server.webhook.WebhookVerifier.HEADER_SIGNATURE;
+import static io.portone.sdk.server.webhook.WebhookVerifier.HEADER_TIMESTAMP;
 
-import static io.portone.sdk.server.webhook.WebhookVerifier.*;
-
-// 포트원 결제 웹훅의 진입점을 담당하는 컨트롤러
-// 1. 포트원으로부터 전달된 raw body와 웹훅 헤더를 수신한다
+// PortOne 결제 웹훅 요청의 진입점을 담당하는 컨트롤러다.
+// 1. PortOne으로부터 전달받은 raw body와 헤더를 수신한다.
 // 2. Webhook-Id, Webhook-Signature, Webhook-Timestamp 헤더를 추출한다.
 // 3. 실제 서명 검증, payload 파싱, 비즈니스 처리는 WebhookService에 위임한다.
 @Slf4j
@@ -22,22 +26,15 @@ public class WebhookController {
 
     private final WebhookService webhookService;
 
-    // 포트원 웹훅 요청을 수신한다
+    // PortOne 웹훅 요청을 수신한다.
     @PostMapping
     public PortOneWebhookResponse receiveWebhook(
             @RequestBody String rawBody,
             HttpServletRequest httpServletRequest
     ) {
-        log.info(
-                "[Webhook][헤더] webhookId={}, webhookTimestamp={}",
-                httpServletRequest.getHeader(HEADER_ID),
-                httpServletRequest.getHeader(HEADER_TIMESTAMP));
-
         String webhookId = httpServletRequest.getHeader(HEADER_ID);
         String webhookSignature = httpServletRequest.getHeader(HEADER_SIGNATURE);
         String webhookTimestamp = httpServletRequest.getHeader(HEADER_TIMESTAMP);
-
-        log.info("[Webhook][매핑] webhookId={}", webhookId);
 
         return webhookService.processWebhook(
                 webhookId,

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/dto/CancelPaymentRequest.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/dto/CancelPaymentRequest.java
@@ -1,8 +1,0 @@
-package sparta.paymentsystemserver.domain.payment.dto;
-
-// 전액 환불 요청 dto
-public record CancelPaymentRequest(
-        // 환불 요청 사유
-        String reason
-) {
-}

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentFinalizeService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentFinalizeService.java
@@ -1,0 +1,72 @@
+package sparta.paymentsystemserver.domain.payment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.paymentsystemserver.domain.payment.dto.PaymentResultResponse;
+import sparta.paymentsystemserver.domain.payment.entity.Payment;
+import sparta.paymentsystemserver.domain.payment.entity.PaymentStatus;
+import sparta.paymentsystemserver.domain.payment.exception.PaymentException;
+import sparta.paymentsystemserver.domain.payment.repository.PaymentRepository;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
+
+// 결제 최종 반영 전용 서비스
+// 외부 결제 상태 검증이 끝난 뒤에 payment를 비관적 락으로 다시 조회
+// READY 상태인 결제만 최종 확정하고 이미 PAID 상태인 경우 멱등하게 성공 처리한다
+// PaymentService에서 외부 포트원 조회를 끝낸 뒤에 이 서비스를 호출하도록 분리해서 디비 락을 잡은 상태로 외부 api 응답을 기다리지 않도록 함
+@Service
+@RequiredArgsConstructor
+public class PaymentFinalizeService {
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentTransactionProcessor paymentTransactionProcessor;
+
+    // 내부 결제를 최종 확정함. 내부 결제 외부 PG 조회가 필요 없으니까 짧은 트랜잭션 안에서 payment 상태와 주문 상태만 반영
+    @Transactional
+    public PaymentResultResponse finalizeInternalPayment(String paymentId) {
+        Payment payment = paymentRepository.findByPaymentIdForUpdate(paymentId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        if (payment.getStatus() == PaymentStatus.PAID) {
+            return toResult(payment);
+        }
+
+        if (payment.getStatus() != PaymentStatus.READY) {
+            throw new PaymentException(ErrorCode.PAYMENT_CONFIRM_NOT_ALLOWED);
+        }
+
+        paymentTransactionProcessor.processSuccess(payment, "INTERNAL");
+        return toResult(payment);
+    }
+
+    // 포트원 결제를 최종 확정함
+    // 외부 결제 상태와 금액 검증은 이미 끝난 상태라고 가정하고 여기서는 최종 상태 반영만 처리
+    // 이 메서드는 보상 처리까지 수행하지 않음 최종 반영 실패하면 예외만 던지고 실제 외부 취소와 보상은 PaymentService에서 처리
+    @Transactional
+    public PaymentResultResponse finalizePortOnePayment(String paymentId, String providerTransactionId) {
+        Payment payment = paymentRepository.findByPaymentIdForUpdate(paymentId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        if (payment.getStatus() == PaymentStatus.PAID) {
+            return toResult(payment);
+        }
+
+        if (payment.getStatus() != PaymentStatus.READY) {
+            throw new PaymentException(ErrorCode.PAYMENT_CONFIRM_NOT_ALLOWED);
+        }
+
+        paymentTransactionProcessor.processSuccess(payment, providerTransactionId);
+        return toResult(payment);
+    }
+
+
+    // 결제 성공 응답 dto 생성
+    private PaymentResultResponse toResult(Payment payment) {
+        return new PaymentResultResponse(
+                true,
+                payment.getPaymentId(),
+                payment.getOrder().getOrderId(),
+                payment.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentService.java
@@ -22,7 +22,8 @@ import sparta.paymentsystemserver.global.exception.ErrorCode;
 import sparta.paymentsystemserver.global.util.PublicIdGenerator;
 
 
-// 결제 시도 생성과 결제 확정을 담당하는 서비스입니다
+// 결제 생성, 결제 확정 요청 진입, 외부 결제 상태 검증 흐름을 조율하는 서비스
+// 실제 최종 상태 반영은 PaymentFinalizeService에 위임함
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
@@ -33,6 +34,7 @@ public class PaymentService {
     private final PublicIdGenerator publicIdGenerator;
     private final PortOnePaymentClient portOnePaymentClient;
     private final PaymentTransactionProcessor paymentTransactionProcessor;
+    private final PaymentFinalizeService paymentFinalizeService;
 
     // 결제 시도 생성 메서드
     // 이 단계에서는 실제 결제를 확정하지 않고, 프론트가 포트원 결제창을 열기 전에 서버에 READY 상태 결제를 미리 저장하는 용도
@@ -98,99 +100,119 @@ public class PaymentService {
         );
     }
 
-    // 결제 확정 메서드
-    // 클라이언트가 결제 성공이라고 보내더라도 서버가 포트원 결제 조회 API를 호출해 최종 상태를 검증한 뒤에만 결제를 확정
-    @Transactional
+    // 사용자가 직접 결제 확정을 요청하는 진입 메서드
+    // - 최초 진입에서는 payment를 조회해서 권한만 검증 -> 외부 포트원 조회는 db 락 없이 먼저 수행
+    // -> 실제 상태 변경이 필요한 시점에만 별도 메서드에서 비관적 락을 잡음
     public PaymentResultResponse confirmPayment(String paymentId, Long userId) {
-        Payment payment = paymentRepository.findByPaymentIdForUpdate(paymentId)
+        Payment payment = paymentRepository.findByPaymentId(paymentId)
                 .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
 
-        // 본인 결제만 확정할 수 있도록 소유권 검사
+        // 본인 결제만 확정할 수 있도록 권한을 먼저 검증한다.
         if (!payment.getUser().getId().equals(userId)) {
             throw new PaymentException(ErrorCode.ORDER_ACCESS_DENIED);
         }
-        return confirmPaymentInternal(payment);
+
+        return confirmPaymentInternal(paymentId);
     }
 
-
-    // 웹훅에서도 결제 확정 로직 재사용
-    @Transactional
+    // 웹훅에서 결제 확정을 위임받아서 처리하는 진입 메서드
+    // 웹훅 처리도 payment 존재만 확인하고 실제 상태 변경은 최종 반영 단계에서만 락 잡아서 처리
     public PaymentResultResponse confirmPaymentByWebhook(String paymentId) {
-        Payment payment = paymentRepository.findByPaymentIdForUpdate(paymentId)
+        paymentRepository.findByPaymentId(paymentId)
                 .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
 
-        return confirmPaymentInternal(payment);
+        return confirmPaymentInternal(paymentId);
     }
 
 
 
     // 실제 결제 확정 공통 로직
-    // 결제 상태, 포트원 조회 결과, 금액 일치 여부를 검증한 뒤에 최족 확정
-    private PaymentResultResponse confirmPaymentInternal(Payment payment) {
+    // 1. payment를 락 없이 조회해서 현재 상태 확인
+    // 2. 이미 PAID면 멱등하게 성공 응답 반환
+    // 3. READY 상태가 아니면 확정 불가로 봄
+    // 4. INTERNAL 결제는 외부 조회 없이 바로 최종 반영 단계로 감
+    // 5. 포트원 결제는 외부 결제 상태를 먼저 조회함
+    // 6. 외부 결제 상태와 금액 검증이 끝난 뒤에만 최종 반영 메서드에서 락 잡음
+    private PaymentResultResponse confirmPaymentInternal(String paymentId) {
+        Payment snapshot = paymentRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
 
-        // 이미 결제 완료된 상태라면 멱등하게 그대로 성공 응답 반환
-        if (payment.getStatus() == PaymentStatus.PAID) {
+        // 이미 결제 완료된 상태라면 멱등하게 성공 응답을 반환한다.
+        if (snapshot.getStatus() == PaymentStatus.PAID) {
             return new PaymentResultResponse(
                     true,
-                    payment.getPaymentId(),
-                    payment.getOrder().getOrderId(),
-                    payment.getStatus().name()
+                    snapshot.getPaymentId(),
+                    snapshot.getOrder().getOrderId(),
+                    snapshot.getStatus().name()
             );
         }
 
-        // READY 상태만 확정 가능
-        if (payment.getStatus() != PaymentStatus.READY) {
+        // READY 상태인 결제만 확정 가능하다.
+        if (snapshot.getStatus() != PaymentStatus.READY) {
             throw new PaymentException(ErrorCode.PAYMENT_CONFIRM_NOT_ALLOWED);
         }
 
-        // 외부 호출이 없는 내부 결제는 즉시 성공 처리
-        if (payment.getProvider() == PaymentProvider.INTERNAL) {
-            paymentTransactionProcessor.processSuccess(payment, "INTERNAL");
-            return toResult(payment);
+        // 외부 PG 호출이 필요 없는 내부 결제는 바로 최종 반영 단계로 넘긴다.
+        if (snapshot.getProvider() == PaymentProvider.INTERNAL) {
+            return paymentFinalizeService.finalizeInternalPayment(paymentId);
         }
 
-        // 포트원 재조회
-        PortOnePaymentInfo paymentInfo = portOnePaymentClient.getPayment(payment.getPaymentId());
+        // PortOne 결제는 외부 API를 먼저 호출해 실제 결제 상태를 검증한다.
+        PortOnePaymentInfo paymentInfo = portOnePaymentClient.getPayment(paymentId);
 
         if (!paymentInfo.isPaid()) {
             paymentTransactionProcessor.handleVerificationFailure(
-                    payment.getPaymentId(),
+                    paymentId,
                     "PortOne 결제 상태가 PAID가 아닙니다."
             );
             throw new PaymentException(ErrorCode.PAYMENT_VERIFICATION_FAILED);
         }
 
-        if (paymentInfo.amount() != payment.getExternalAmount()) {
+        if (paymentInfo.amount() != snapshot.getExternalAmount()) {
             paymentTransactionProcessor.handleVerificationFailure(
-                    payment.getPaymentId(),
-                    "PortOne 승인 금액과 서버 계산 금액이 일치하지 않습니다."
+                    paymentId,
+                    "PortOne 확인 금액과 서버 계산 금액이 일치하지 않습니다."
             );
             throw new PaymentException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
 
         try {
-            // 외부 결제 성공이 검증되면 내부 성공 후처리를 수행
-            paymentTransactionProcessor.processSuccess(payment, paymentInfo.transactionId());
+            return paymentFinalizeService.finalizePortOnePayment(paymentId, paymentInfo.transactionId());
         } catch (Exception exception) {
-            paymentTransactionProcessor.compensate(
-                    payment.getPaymentId(),
-                    "결제 후처리 실패로 인한 자동 취소"
-            );
+            handleFinalizeFailureCompensation(snapshot);
             throw exception;
         }
-
-        return toResult(payment);
-
     }
 
-    // 결제 성공 응답 생성 메서드
-    private PaymentResultResponse toResult(Payment payment) {
-        return new PaymentResultResponse(
-                true,
-                payment.getPaymentId(),
-                payment.getOrder().getOrderId(),
-                payment.getStatus().name()
-        );
+    // 결제 최종 반영이 실패한 뒤 수행하는 보상 처리
+    // PaymentFinalizeService의 트랜잭션이 끝난 뒤에 호출되니까 여기서는 payment row 락이 해제된 상태에서 외부 취소 api를 호출함
+    // - 내부 결제면 바로 보상 트랜잭션만 수행
+    // - 포트원 결제면 외부 취소 api를 먼저 호출
+    // - 외부 취소 성송하면 보상 트랜잭션 수행
+    // - 외부 취소 실패하면 실패 이력 남김
+    private void handleFinalizeFailureCompensation(Payment payment) {
+        if (payment.getProvider() != PaymentProvider.PORTONE) {
+            paymentTransactionProcessor.compensateAfterCancel(
+                    payment.getPaymentId(), "결제 후처리 실패로 인한 내부 결제 보상"
+            );
+            return;
+        }
+
+        try {
+            portOnePaymentClient.cancelPayment(
+                    payment.getPaymentId(), "결제 후처리 실패로 인한 자동 취소"
+            );
+
+            paymentTransactionProcessor.compensateAfterCancel(
+                    payment.getPaymentId(), "결제 후처리 실패로 인한 자동 취소"
+            );
+        } catch (Exception cancelException) {
+            paymentTransactionProcessor.markCompensationFailure(
+                    payment.getPaymentId(), "결제 후처리 실패 및 PortOne 자동 취소 실패"
+            );
+
+            throw new PaymentException(ErrorCode.REFUND_PROCESS_FAILED);
+        }
     }
+
 }
-

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentTimeoutScheduler.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentTimeoutScheduler.java
@@ -2,6 +2,7 @@ package sparta.paymentsystemserver.domain.payment.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +38,7 @@ public class PaymentTimeoutScheduler {
 
     // 1분마다 만료 대상 주문을 검사
     @Scheduled(fixedDelay = 60_000)
+    @SchedulerLock(name = "paymentTimeoutScheduler_expirePendingOrders", lockAtMostFor = "PT55S", lockAtLeastFor = "PT5S")
     @Transactional
     public void expirePendingOrders() {
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(PAYMENT_TIMEOUT_MINUTES);

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentTransactionProcessor.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentTransactionProcessor.java
@@ -8,11 +8,9 @@ import sparta.paymentsystemserver.domain.order.entity.Order;
 import sparta.paymentsystemserver.domain.order.entity.OrderItem;
 import sparta.paymentsystemserver.domain.order.repository.OrderItemRepository;
 import sparta.paymentsystemserver.domain.payment.entity.Payment;
-import sparta.paymentsystemserver.domain.payment.entity.PaymentProvider;
 import sparta.paymentsystemserver.domain.payment.exception.PaymentException;
 import sparta.paymentsystemserver.domain.payment.repository.PaymentRepository;
 import sparta.paymentsystemserver.domain.point.service.PointService;
-import sparta.paymentsystemserver.global.client.PortOnePaymentClient;
 import sparta.paymentsystemserver.global.exception.ErrorCode;
 
 // 결제 성공 후에 내부 상태 반영이랑 실패하면 보상 처리를 담당
@@ -22,7 +20,6 @@ import sparta.paymentsystemserver.global.exception.ErrorCode;
 public class PaymentTransactionProcessor {
 
     private final PointService pointService;
-    private final PortOnePaymentClient portOnePaymentClient;
     private final PaymentRepository paymentRepository;
     private final OrderItemRepository orderItemRepository;
 
@@ -56,27 +53,28 @@ public class PaymentTransactionProcessor {
         restoreOrderStock(payment.getOrder());
     }
 
-
-    // 외부 결제는 성공했지만 내부 후처리 중 실패한 경우 보상 트랜잭션을 수행 포트원 결제는 자동 취소 내부 결제는 실패 상태만 남김
+    // 결제 후처리 실패 뒤에 외부 결제 취소까지 성공한 경우 로컬 DB 상태를 보상 트랜잭션으로 정리함
+    // 이 메서드는 외부 API 호출 없이 DB 상태 변경만 담당
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void compensate(String paymentId, String failureReason) {
+    public void compensateAfterCancel(String paymentId, String failureReason) {
         Payment payment = paymentRepository.findByPaymentId(paymentId)
                 .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
 
-        if (payment.getProvider() == PaymentProvider.PORTONE) {
-            try {
-                portOnePaymentClient.cancelPayment(
-                        payment.getPaymentId(),
-                        "결제 후처리 실패로 인한 자동 취소"
-                );
-            } catch (Exception exception) {
-                payment.markFailed("결제 후처리 실패 및 PortOne 자동 취소 실패");
-                throw new PaymentException(ErrorCode.REFUND_PROCESS_FAILED);
-            }
-        }
         payment.markFailed(failureReason);
         payment.getOrder().cancel();
         restoreOrderStock(payment.getOrder());
+    }
+
+
+    // 결제 후처리 실패 뒤 외부 결제 취소까지 실패한 경우 최소한의 결제 실패 이력은 별도 트랜잭션으로 남긴다
+    // 외부 결제가 실제로 취소되지 않았을 수 있으니까 주문 취소나 재고 복구까지 단정해서 처리하지 않고
+    // 우선 실패 상태와 사유만 남겨서 후속 대응이 가능하게 함
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markCompensationFailure(String paymentId, String failureReason) {
+        Payment payment = paymentRepository.findByPaymentId(paymentId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        payment.markFailed(failureReason);
     }
 
     // 주문 생성 했을 때 미리 차감했던 재고 돌림
@@ -86,3 +84,4 @@ public class PaymentTransactionProcessor {
         }
     }
 }
+

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/WebhookService.java
@@ -10,6 +10,7 @@ import sparta.paymentsystemserver.domain.payment.entity.PaymentStatus;
 import sparta.paymentsystemserver.domain.payment.entity.PaymentWebhookEvent;
 import sparta.paymentsystemserver.domain.payment.repository.PaymentRepository;
 import sparta.paymentsystemserver.domain.payment.repository.PaymentWebhookEventRepository;
+import sparta.paymentsystemserver.domain.refund.service.RefundService;
 import tools.jackson.databind.ObjectMapper;
 
 // 포트원 웹훅 처리 서비스

--- a/src/main/java/sparta/paymentsystemserver/domain/point/scheduler/PointExpirationScheduler.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/point/scheduler/PointExpirationScheduler.java
@@ -2,6 +2,7 @@ package sparta.paymentsystemserver.domain.point.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import sparta.paymentsystemserver.domain.point.entity.PointTransaction;
@@ -20,6 +21,7 @@ public class PointExpirationScheduler {
     private final PointExpirationService pointExpirationService;
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정 00시
+    @SchedulerLock(name = "pointExpirationScheduler_expirePoints", lockAtMostFor = "PT30M", lockAtLeastFor = "PT10S")
     public void expirePoints() {
         log.info("[포인트 만료 스케쥴러] 실행 시작");
 

--- a/src/main/java/sparta/paymentsystemserver/domain/point/scheduler/PurchaseConfirmScheduler.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/point/scheduler/PurchaseConfirmScheduler.java
@@ -2,6 +2,7 @@ package sparta.paymentsystemserver.domain.point.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +25,7 @@ public class PurchaseConfirmScheduler {
     private static final long CONFIRM_AFTER_DAYS = 7L;
 
     @Scheduled(cron = "0 0 0 * * *") // 매일 자정 00시
+    @SchedulerLock(name = "purchaseConfirmScheduler_confirmPurchase", lockAtMostFor = "PT30M", lockAtLeastFor = "PT10S")
     @Transactional
     public void confirmPurchase() {
         log.info("[구매확정 스케쥴러] 실행 시작");

--- a/src/main/java/sparta/paymentsystemserver/domain/refund/controller/RefundController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/refund/controller/RefundController.java
@@ -1,0 +1,28 @@
+package sparta.paymentsystemserver.domain.refund.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import sparta.paymentsystemserver.domain.auth.dto.LoginUserData;
+import sparta.paymentsystemserver.domain.payment.dto.PaymentResultResponse;
+import sparta.paymentsystemserver.domain.refund.dto.RefundRequest;
+import sparta.paymentsystemserver.domain.refund.service.RefundService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+public class RefundController {
+
+    private final RefundService refundService;
+
+    // 전액 환불 요청 API, 클라이언트는 환불 요청만 보내고 실제 포트원 결제 취소와 내부 환불 상태 반영은 서버가 책임진다
+    @PostMapping("/{paymentId}/cancel")
+    public PaymentResultResponse cancelPayment(
+            @PathVariable String paymentId,
+            @RequestBody RefundRequest request,
+            @AuthenticationPrincipal LoginUserData loginUserData
+    ) {
+        return refundService.cancelPayment(paymentId, loginUserData.userId(), request.reason());
+    }
+
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/refund/dto/RefundRequest.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/refund/dto/RefundRequest.java
@@ -1,0 +1,8 @@
+package sparta.paymentsystemserver.domain.refund.dto;
+
+// 전액 환불 요청 dto
+public record RefundRequest(
+        // 환불 요청 사유
+        String reason
+) {
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/refund/entity/Refund.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/refund/entity/Refund.java
@@ -1,10 +1,11 @@
-package sparta.paymentsystemserver.domain.payment.entity;
+package sparta.paymentsystemserver.domain.refund.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sparta.paymentsystemserver.domain.payment.entity.Payment;
 import sparta.paymentsystemserver.global.config.BaseEntity;
 
 // 환불 이력 엔티티

--- a/src/main/java/sparta/paymentsystemserver/domain/refund/entity/RefundStatus.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/refund/entity/RefundStatus.java
@@ -1,4 +1,4 @@
-package sparta.paymentsystemserver.domain.payment.entity;
+package sparta.paymentsystemserver.domain.refund.entity;
 
 // 환불 이력의 처리 상태
 public enum RefundStatus {

--- a/src/main/java/sparta/paymentsystemserver/domain/refund/repository/RefundRepository.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/refund/repository/RefundRepository.java
@@ -1,7 +1,7 @@
-package sparta.paymentsystemserver.domain.payment.repository;
+package sparta.paymentsystemserver.domain.refund.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import sparta.paymentsystemserver.domain.payment.entity.Refund;
+import sparta.paymentsystemserver.domain.refund.entity.Refund;
 
 import java.util.Optional;
 

--- a/src/main/java/sparta/paymentsystemserver/domain/refund/service/RefundFinalizeService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/refund/service/RefundFinalizeService.java
@@ -1,0 +1,123 @@
+package sparta.paymentsystemserver.domain.refund.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sparta.paymentsystemserver.domain.payment.dto.PaymentResultResponse;
+import sparta.paymentsystemserver.domain.payment.entity.Payment;
+import sparta.paymentsystemserver.domain.payment.entity.PaymentStatus;
+import sparta.paymentsystemserver.domain.refund.entity.Refund;
+import sparta.paymentsystemserver.domain.refund.entity.RefundStatus;
+import sparta.paymentsystemserver.domain.payment.exception.PaymentException;
+import sparta.paymentsystemserver.domain.payment.repository.PaymentRepository;
+import sparta.paymentsystemserver.domain.refund.repository.RefundRepository;
+import sparta.paymentsystemserver.global.exception.ErrorCode;
+import sparta.paymentsystemserver.global.util.PublicIdGenerator;
+
+
+// 환불 최종 반영 전용 서비스
+// - 외부 포트원 취소 호출이 이미 성공한 뒤 DB 상태를 트랜잭션으로 반영
+// - 환불 이력 저장
+// - 포인트/재고/적립 취소 후처리를 RefundTransactionProcessor에 위임
+// - payment/order 상태를 최종 REFUNDED 상태로 바꿈
+@Service
+@RequiredArgsConstructor
+public class RefundFinalizeService {
+
+    private final PaymentRepository paymentRepository;
+    private final RefundRepository refundRepository;
+    private final PublicIdGenerator publicIdGenerator;
+    private final RefundTransactionProcessor refundTransactionProcessor;
+
+
+    // 수동 환불 요청의 최종 반영을 수행함 이미 외부 결제 취소가 끝났다는 전제 하에 로컬 DB 상태만 반영
+    @Transactional
+    public PaymentResultResponse finalizeRefund(
+            String paymentId,
+            long refundAmount,
+            String reason,
+            String providerRefundId
+    ) {
+        Payment payment = paymentRepository.findByPaymentIdForUpdate(paymentId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        // 이미 환불 완료된 결제라면 멱등하게 성공 응답을 반환
+        if (payment.getStatus() == PaymentStatus.REFUNDED) {
+            return toResult(payment);
+        }
+
+        // PAID 상태인 결제만 환불 최종 반영 가능
+        if (payment.getStatus() != PaymentStatus.PAID) {
+            throw new PaymentException(ErrorCode.REFUND_NOT_ALLOWED);
+        }
+
+        // 이미 환불 이력이 있으면 중복 생성하지 않음
+        if (!refundRepository.existsByPaymentId(payment.getId())) {
+            Refund refund = Refund.create(
+                    publicIdGenerator.generate("REF"),
+                    payment,
+                    refundAmount,
+                    reason,
+                    RefundStatus.COMPLETED,
+                    providerRefundId
+            );
+            refundRepository.save(refund);
+        }
+
+        refundTransactionProcessor.processRefund(payment);
+        payment.markRefunded();
+        payment.getOrder().refund();
+
+        return toResult(payment);
+    }
+
+
+    // 웹훅 기반 환불 동기화 최종 반영. 포트원에서 이미 취소/환불이 완료됐다는 사실을 웹훅으로 전달받았을 때 그 결과에 맞춰 동기화
+    @Transactional
+    public void finalizeRefundFromWebhook(
+            String paymentId,
+            String providerRefundId,
+            String reason
+    ) {
+        Payment payment = paymentRepository.findByPaymentIdForUpdate(paymentId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
+
+        if (payment.getStatus() == PaymentStatus.REFUNDED) {
+            return;
+        }
+
+        if (refundRepository.existsByPaymentId(payment.getId())) {
+            payment.markRefunded();
+            payment.getOrder().refund();
+            return;
+        }
+
+        if (payment.getStatus() != PaymentStatus.PAID) {
+            return;
+        }
+
+        Refund refund = Refund.create(
+                publicIdGenerator.generate("REF"),
+                payment,
+                payment.getTotalAmount(),
+                reason,
+                RefundStatus.COMPLETED,
+                providerRefundId
+        );
+
+        refundRepository.save(refund);
+        refundTransactionProcessor.processRefund(payment);
+        payment.markRefunded();
+        payment.getOrder().refund();
+    }
+
+    // 환불 완료 응답 dto 생성
+    private PaymentResultResponse toResult(Payment payment) {
+        return new PaymentResultResponse(
+                true,
+                payment.getPaymentId(),
+                payment.getOrder().getOrderId(),
+                payment.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/sparta/paymentsystemserver/domain/refund/service/RefundService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/refund/service/RefundService.java
@@ -1,22 +1,18 @@
-package sparta.paymentsystemserver.domain.payment.service;
+package sparta.paymentsystemserver.domain.refund.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import sparta.paymentsystemserver.domain.payment.dto.PaymentResultResponse;
 import sparta.paymentsystemserver.domain.payment.entity.Payment;
 import sparta.paymentsystemserver.domain.payment.entity.PaymentProvider;
 import sparta.paymentsystemserver.domain.payment.entity.PaymentStatus;
-import sparta.paymentsystemserver.domain.payment.entity.Refund;
-import sparta.paymentsystemserver.domain.payment.entity.RefundStatus;
 import sparta.paymentsystemserver.domain.payment.exception.PaymentException;
 import sparta.paymentsystemserver.domain.payment.repository.PaymentRepository;
-import sparta.paymentsystemserver.domain.payment.repository.RefundRepository;
+import sparta.paymentsystemserver.domain.refund.repository.RefundRepository;
 import sparta.paymentsystemserver.global.client.PortOnePaymentClient;
 import sparta.paymentsystemserver.global.client.dto.PortOneCancelInfo;
 import sparta.paymentsystemserver.global.exception.ErrorCode;
-import sparta.paymentsystemserver.global.util.PublicIdGenerator;
 
 // 결제 환불 처리 서비스 환불 가능 여부 검증하고 바깥의 취소 요청과 내부 상태 변경 함께 처리함
 @Slf4j
@@ -27,88 +23,43 @@ public class RefundService {
     private final PaymentRepository paymentRepository;
     private final RefundRepository refundRepository;
     private final PortOnePaymentClient portOnePaymentClient;
-    private final PublicIdGenerator publicIdGenerator;
-    private final RefundTransactionProcessor refundTransactionProcessor;
+    private final RefundFinalizeService refundFinalizeService;
 
-    // 사용자 결제 환불 처리 외부 결제에서는 포트원에 취소를 요청하고 내부 결제(포인트 결제 등)에서는 즉시 환불 이력 생성
-    @Transactional
+    // 사용자의 수동 환불 요청 진입 메서드
+    // 1. payment를 조회해서 권한과 상태를 검증
+    // 2. 포트원 결제인 경우에 외부 취소 api를 먼저 호출
+    // 3. 외부 취소가 끝난 뒤 RefundFinalizeService에서 DB 상태 반영
     public PaymentResultResponse cancelPayment(String paymentId, Long userId, String reason) {
         Payment payment = paymentRepository.findByPaymentId(paymentId)
                 .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
 
         validateRefundRequest(payment, userId);
 
-        if(payment.getOrder().isConfirmed()) {
+        if (payment.getOrder().isConfirmed()) {
             return toFailResult(payment);
         }
 
-        // 이미 환불 완료된 결제는 성공 응답만 돌려줌
+        // 이미 환불 완료된 결제라면 멱등하게 성공 응답을 반환
         if (payment.getStatus() == PaymentStatus.REFUNDED) {
             return toResult(payment);
         }
 
         RefundExecution refundExecution = executeRefund(payment, reason);
 
-        // 외부 환불이 성공한 뒤에는 내부 환불 이력을 남김
-        Refund refund = Refund.create(
-                publicIdGenerator.generate("REF"),
-                payment,
+        return refundFinalizeService.finalizeRefund(
+                payment.getPaymentId(),
                 refundExecution.refundAmount(),
                 reason,
-                RefundStatus.COMPLETED,
                 refundExecution.providerRefundId()
         );
-
-        refundRepository.save(refund);
-
-        // 환불 완료 후에 내부에 처리 수행
-        refundTransactionProcessor.processRefund(payment);
-
-        // 결제랑 주문 상태를 최종 환불 상태로 전환
-        payment.markRefunded();
-        payment.getOrder().refund();
-
-        return toResult(payment);
     }
 
-    // 외부에서 이미 취소된 결제를 포트원 웹훅으로 동기화 우리 서버는 내부 환불 상태만 맞춤
-    @Transactional
+    // 포트원 웹훅으로 이미 취소/환불된 결제를 동기화함
+    // 이 메서드는 외부 api를 다시 호출하지 않고 포트원이 보내준 결과를 기준으로 환불 상태만 맞춤
     public void syncRefundFromWebhook(String paymentId, String providerRefundId, String reason) {
-        Payment payment = paymentRepository.findByPaymentId(paymentId)
-                .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_NOT_FOUND));
+        refundFinalizeService.finalizeRefundFromWebhook(paymentId, providerRefundId, reason);
 
-        if (payment.getStatus() == PaymentStatus.REFUNDED) {
-            log.info("[RefundSync] already refunded. paymentId={}", paymentId);
-            return;
-        }
-
-        if (refundRepository.existsByPaymentId(payment.getId())) {
-            log.info("[RefundSync] refund history already exists. paymentId={}", paymentId);
-            payment.markRefunded();
-            payment.getOrder().refund();
-            return;
-        }
-
-        if (payment.getStatus() != PaymentStatus.PAID) {
-            log.info("[RefundSync] payment is not PAID. skip sync. paymentId={}, status={}", paymentId, payment.getStatus());
-            return;
-        }
-
-        Refund refund = Refund.create(
-                publicIdGenerator.generate("REF"),
-                payment,
-                payment.getTotalAmount(),
-                reason,
-                RefundStatus.COMPLETED,
-                providerRefundId
-        );
-
-        refundRepository.save(refund);
-        refundTransactionProcessor.processRefund(payment);
-        payment.markRefunded();
-        payment.getOrder().refund();
-
-        log.info("[RefundSync] synced refund from webhook. paymentId={}, providerRefundId={}", paymentId, providerRefundId);
+        log.info("[RefundSync] 웹훅 기준 환불 동기화를 완료했습니다. paymentId={}, providerRefundId={}", paymentId, providerRefundId);
     }
 
     // 환불 요청 유효한지 검증. 본인 결제 여부랑 결제 상태랑 중복 환불 여부를 확인함
@@ -130,7 +81,9 @@ public class RefundService {
         }
     }
 
-    // 포트원 결제는 외부 취소 내부 결제는 내부 금액 기준으로 처리
+    // 외부 결제 취소를 수행하고 환불 결과를 반환
+    // 내부 결제는 외부 호출이 필요 없으니까 전체 금액 기준 결과를 바로 만든다
+    // 포트원 결제는 취소 api 호출해서 실제 취소 결과를 확인한다
     private RefundExecution executeRefund(Payment payment, String reason) {
         if (payment.getProvider() != PaymentProvider.PORTONE) {
             // 실제 주문 기준 환불 금액을 이력에 남김

--- a/src/main/java/sparta/paymentsystemserver/domain/refund/service/RefundTransactionProcessor.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/refund/service/RefundTransactionProcessor.java
@@ -1,4 +1,4 @@
-package sparta.paymentsystemserver.domain.payment.service;
+package sparta.paymentsystemserver.domain.refund.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/sparta/paymentsystemserver/domain/subscription/service/SubscriptionScheduler.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/subscription/service/SubscriptionScheduler.java
@@ -2,6 +2,7 @@ package sparta.paymentsystemserver.domain.subscription.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ public class SubscriptionScheduler {
 
     // 구독 스케줄러 메인 실행 메서드 매시간 0분 0초에 실행함
     @Scheduled(cron = "0 0 * * * *")
+    @SchedulerLock(name = "subscriptionScheduler_runSubscriptionScheduler", lockAtMostFor = "PT50M", lockAtLeastFor = "PT10S")
     @Transactional
     public void runSubscriptionScheduler() {
         log.info("[구독 스케줄러] 실행 시작");

--- a/src/main/java/sparta/paymentsystemserver/global/config/ShedLockConfig.java
+++ b/src/main/java/sparta/paymentsystemserver/global/config/ShedLockConfig.java
@@ -1,0 +1,27 @@
+package sparta.paymentsystemserver.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+// 여러 서버 인스턴스가 동시에 떠 있어도 동일한 스케줄 작업이 한 번만 실행되도록 DB 기반 분산 락을 설정한다
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build()
+        );
+    }
+
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,8 @@
+-- 멀티 인스턴스 환경에서 스케줄러 중복 실행을 방지하기 위한 ShedLock 전용 테이블
+-- 스케줄 작업별 락 상태를 DB에 저장해 한 번만 실행되도록 제어함
+CREATE TABLE IF NOT EXISTS shedlock (
+    name VARCHAR(64) NOT NULL PRIMARY KEY,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL,
+    locked_by VARCHAR(255) NOT NULL
+);


### PR DESCRIPTION
**작업 설명**
- 결제 확정 흐름에서 외부 PortOne 조회와 DB 최종 반영을 분리했습니다.
- PaymentFinalizeService를 도입해 payment row 락 구간을 짧게 유지하도록 정리했습니다.
- 결제 후처리 실패 시 외부 취소 호출과 로컬 보상 반영 책임을 나눠 병목 가능성을 줄였습니다.
- 환불 흐름도 외부 취소 호출과 로컬 상태 반영을 분리했습니다.
- RefundFinalizeService를 도입하고, 환불 관련 엔티티/리포지토리/서비스/컨트롤러/DTO를 refund 도메인으로 이동했습니다.
- 웹훅 처리 흐름을 정리하고, Transaction.Cancelled 처리 시 cancellationId 기반으로 환불 동기화되도록 수정했습니다.

**수락 기준**
- 결제 확정 시 외부 PortOne 조회가 payment row 락 구간 밖에서 수행된다.
