### PR TITLE
refactor : 포인트 획득 시 계산하던 total amount, grade 분리

### DIFF
--- a/src/main/java/sparta/paymentsystemserver/domain/order/controller/OrderController.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/order/controller/OrderController.java
@@ -62,9 +62,10 @@ public class OrderController {
 
     @PatchMapping("/{orderId}/confirmed")
     public ResponseEntity<Void> confirmOrder(
+            @AuthenticationPrincipal LoginUserData loginUserData,
             @PathVariable String orderId
     ){
-        orderService.confirmOrder(orderId);
+        orderService.confirmOrder(orderId, loginUserData.userId());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/sparta/paymentsystemserver/domain/order/service/OrderService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/order/service/OrderService.java
@@ -1,6 +1,5 @@
 package sparta.paymentsystemserver.domain.order.service;
 
-import org.jspecify.annotations.Nullable;
 import sparta.paymentsystemserver.domain.order.dto.*;
 
 import java.util.List;
@@ -14,7 +13,7 @@ public interface OrderService {
 
     updateOrderStatusResponse processDelivery(String orderId);
 
-    void confirmOrder(String orderId);
+    void confirmOrder(String orderId, Long userId);
 
     List<GetOrderListResponse> getAllOrders();
 }

--- a/src/main/java/sparta/paymentsystemserver/domain/order/service/OrderServiceImpl.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/order/service/OrderServiceImpl.java
@@ -173,11 +173,18 @@ public class OrderServiceImpl implements OrderService {
         return new updateOrderStatusResponse(true,orderId,order.getStatus().name());
     }
 
-    public void confirmOrder(String orderId) {
+    public void confirmOrder(String orderId , Long userId) {
+        User user = userService.findById(userId);
         Order order = getOrder(orderId);
-        if(order.getUsedPoints() == 0L){
-            pointService.earnPoints(order.getUser().getId(), order, order.getTotalAmount());
+
+        if(!user.getId().equals(order.getUser().getId())) {
+            throw new OrderException(ErrorCode.ORDER_ACCESS_DENIED);
         }
+        if(order.getUsedPoints() == 0L){
+            pointService.earnPoints(user, order, order.getTotalAmount());
+        }
+        user.addTotalPaidAmount(order.getTotalAmount());
+        userService.calculateGrade(user);
         order.purchaseConfirmed();
     }
 

--- a/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentTransactionProcessor.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/payment/service/PaymentTransactionProcessor.java
@@ -37,7 +37,7 @@ public class PaymentTransactionProcessor {
         pointService.spendPoints(payment.getUser().getId(), order, payment.getPointsToUse());
 
         // 실제 외부 결제 금액 기준으로 적립 포인트를 계산하고 누적 결제 금액과 멤버십 등급도 함께 갱신
-//        pointService.earnPoints(payment.getUser().getId(), order, payment.getExternalAmount());
+        // pointService.earnPoints(payment.getUser().getId(), order, payment.getExternalAmount());
 
         // 모든 내부 반영이 끝난 뒤 주문을 결제 완료 상태로 전환
         order.completePurchase();

--- a/src/main/java/sparta/paymentsystemserver/domain/point/scheduler/PurchaseConfirmScheduler.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/point/scheduler/PurchaseConfirmScheduler.java
@@ -47,7 +47,7 @@ public class PurchaseConfirmScheduler {
             try {
                 order.purchaseConfirmed();
                 pointService.earnPoints(
-                        order.getUser().getId(),
+                        order.getUser(),
                         order,
                         order.getTotalAmount()
                 );

--- a/src/main/java/sparta/paymentsystemserver/domain/point/service/PointService.java
+++ b/src/main/java/sparta/paymentsystemserver/domain/point/service/PointService.java
@@ -42,9 +42,7 @@ public class PointService {
 
 //    구매확정 시 포인트 적립
     @Transactional
-    public void earnPoints(Long userId, Order order, Long paymentAmount) {
-        User user = userService.findById(userId);
-
+    public void earnPoints(User user, Order order, Long paymentAmount) {
         MembershipGradePolicy membershipGradePolicy = userService.getUserMemberShip(user);
 
         long points = BigDecimal.valueOf(paymentAmount)
@@ -65,11 +63,8 @@ public class PointService {
             user.addPoint(points);
         }
 
-        user.addTotalPaidAmount(paymentAmount);
-        userService.calculateGrade(user);
-
         log.info("[포인트 적립] userId: {}, 결제금액: {}, 적립포인트: {}, 등급: {}",
-                userId, paymentAmount, points, user.getMembershipGrade());
+                user.getId(), paymentAmount, points, user.getMembershipGrade());
     }
 
 //    결제 확정 시 포인트 사용


### PR DESCRIPTION
- 포인트 획득과 시 total amount, grade를 검증하면 포인트를 사용한결제( 적립X ) 에서는 해당 로직이 수행되고있지 않음
- 해당 로직을 구매확정 시점으로 변경하여 구매 확정 시점에서 고객의 총 계산금액과 등급을 재계산 하도록 로직 변경
- earnPoints 등에서 userId를 받아 DB재 조회하는 부분을 User 객체로 받아옴
 (1차 캐시로 DB쿼리는 날라가지 않지만 내부 의존성을 숨김으로 다른 개발자들이 볼때 내부에서 DB조회가 일어나는지 알 수 없음, 
 해당 메서드를 호출하는 부분이 모두 이미 User를 조회했거나 getUser를 할 수있는 컨텍스트 안이기때문에 시그니처의 명시성을 높여주는편이 User가 없는 곳에서 호출할 가능성보다 더 중요하다 생각)